### PR TITLE
🧹 [Refactor] Replace unwrap() with expect() in apk.rs test helpers

### DIFF
--- a/system/oil/src/system/registry/apk.rs
+++ b/system/oil/src/system/registry/apk.rs
@@ -343,18 +343,18 @@ mod tests {
             let mut sig_header = tar::Header::new_gnu();
             sig_header
                 .set_path(".SIGN.RSA.alpine-devel@example.rsa.pub")
-                .unwrap();
+                .expect("failed to set path for signature header");
             sig_header.set_size(signature.len() as u64);
             sig_header.set_cksum();
-            archive.append(&sig_header, &signature[..]).unwrap();
+            archive.append(&sig_header, &signature[..]).expect("failed to append signature to archive");
 
             let content = b"P:ripgrep\nV:15.1.0-r0\nT:Search tool\nI:12345\nD:so:libc.musl-aarch64.so.1\np:cmd:rg=15.1.0-r0\n\n";
             let mut header = tar::Header::new_gnu();
-            header.set_path("APKINDEX").unwrap();
+            header.set_path("APKINDEX").expect("failed to set path for APKINDEX header");
             header.set_size(content.len() as u64);
             header.set_cksum();
-            archive.append(&header, &content[..]).unwrap();
-            archive.finish().unwrap();
+            archive.append(&header, &content[..]).expect("failed to append APKINDEX to archive");
+            archive.finish().expect("failed to finish archive");
         }
 
         let packages = parse_apkindex_archive(
@@ -364,7 +364,7 @@ mod tests {
             "community",
             "aarch64",
         )
-        .unwrap();
+        .expect("failed to parse APKINDEX archive");
         assert_eq!(packages.len(), 1);
         assert_eq!(packages[0].name, "ripgrep");
     }


### PR DESCRIPTION
🎯 **What:** Replaced `unwrap()` calls with `.expect()` in `system/oil/src/system/registry/apk.rs` test helper logic.
💡 **Why:** To improve code maintainability and readability by explicitly stating the expected state and providing clear panic messages if setup steps fail during tests.
✅ **Verification:** Verified by running `cargo test` and `cargo clippy` in `system/oil` and executing the full `ci-rust-core.sh` script to ensure all tests pass and no functionality was broken.
✨ **Result:** Improved code health in test logic without altering behavior or correctness.

---
*PR created automatically by Jules for task [1961647267106816220](https://jules.google.com/task/1961647267106816220) started by @undivisible*