### PR TITLE
🧹 Remove unused user and global install args

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -35,10 +35,6 @@ enum Commands {
         packages: Vec<String>,
         #[arg(long)]
         dry_run: bool,
-        #[arg(long, help = "Install to ~/.local/oil (no sudo)")]
-        user: bool,
-        #[arg(long, help = "Install to system directory (may need sudo)")]
-        global: bool,
     },
     /// Uninstall packages
     Uninstall {
@@ -114,13 +110,7 @@ fn run_command(cmd: Commands) -> Result<()> {
             }
             Ok(())
         }
-        Commands::Install {
-            packages,
-            dry_run,
-            user,
-            global,
-        } => {
-            let _ = (user, global);
+        Commands::Install { packages, dry_run } => {
             let registry = system::registry::apk::ApkRegistry::alpine_default();
             let index = registry.load()?;
             let mut state = install::InstallState::new()?;
@@ -165,10 +155,10 @@ fn run_command(cmd: Commands) -> Result<()> {
                 if let Some(_pkg) = state.get(name) {
                     let registry = system::registry::apk::ApkRegistry::alpine_default();
                     let index = registry.load()?;
-                    if let Some(latest) = index.find(&name) {
+                    if let Some(latest) = index.find(name) {
                         let dest = std::path::PathBuf::from("/usr/local");
                         install_package(latest, &dest)?;
-                        state.mark_installed(&name, Some(latest.version.clone()));
+                        state.mark_installed(name, Some(latest.version.clone()));
                         println!("Reinstalled {name} {}", latest.version);
                     }
                 }
@@ -192,7 +182,7 @@ fn run_command(cmd: Commands) -> Result<()> {
                         continue;
                     }
                     if let Some(latest) = index.find(name) {
-                        if &latest.version != &current.version {
+                        if latest.version != current.version {
                             if dry_run {
                                 println!(
                                     "Would upgrade {name}: {} → {}",
@@ -255,10 +245,10 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         .map_err(|e| error::OilError::Install(format!("set permissions: {e}")))?;
 
     eprintln!("Extracting {}...", pkg.name);
-    
+
     let result = system::apk_extract::extract_tracked(tmp.path(), dest);
-    
+
     let _ = std::fs::remove_file(tmp.path());
-    
+
     result.map(|_| ())
 }

--- a/system/oil/src/signal.rs
+++ b/system/oil/src/signal.rs
@@ -1,9 +1,9 @@
 use signal_hook::{consts::SIGINT, iterator::Signals};
 
 pub fn install_handler() {
-    let mut signals = Signals::new(&[SIGINT]).expect("Failed to register signal handler");
+    let mut signals = Signals::new([SIGINT]).expect("Failed to register signal handler");
     std::thread::spawn(move || {
-        for _ in signals.forever() {
+        if signals.forever().next().is_some() {
             eprintln!("\nInterrupted");
             std::process::exit(130);
         }

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -78,7 +78,7 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
 
     let mut starts: Vec<usize> = Vec::new();
     let mut last_pos = 0;
-    
+
     for i in 0..data.len().saturating_sub(1) {
         if data[i] == 0x1f && data[i + 1] == 0x8b {
             if i < last_pos {
@@ -86,13 +86,13 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
             }
             starts.push(i);
             last_pos = i;
-            
+
             if starts.len() >= count {
                 break;
             }
         }
     }
-    
+
     if starts.len() < count {
         return Err(OilError::Install(format!(
             "APK has {} gzip streams, expected {count}",
@@ -102,14 +102,14 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
 
     let mut out = Vec::with_capacity(count);
     let mut total_decompressed: usize = 0;
-    
+
     for i in 0..count {
         let slice = &data[starts[i]..];
         let mut decoder = flate2::read::GzDecoder::new(slice);
         let mut buf = Vec::new();
-        
+
         decoder.read_to_end(&mut buf)?;
-        
+
         if buf.len() > MAX_STREAM_SIZE {
             return Err(OilError::Install(format!(
                 "Stream {} size {} exceeds maximum {}",
@@ -118,19 +118,18 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
                 MAX_STREAM_SIZE
             )));
         }
-        
+
         total_decompressed += buf.len();
         if total_decompressed > MAX_TOTAL_SIZE {
             return Err(OilError::Install(format!(
                 "Total decompressed size {} exceeds maximum {}",
-                total_decompressed,
-                MAX_TOTAL_SIZE
+                total_decompressed, MAX_TOTAL_SIZE
             )));
         }
-        
+
         out.push(buf);
     }
-    
+
     Ok((out.remove(0), out.remove(0), out.remove(0)))
 }
 

--- a/system/oil/src/system/verifier.rs
+++ b/system/oil/src/system/verifier.rs
@@ -80,17 +80,17 @@ pub fn verify_apk_signature(data_tar: &[u8], sig_cms_der: &[u8], pubkey_pem: &st
         .map_err(|e| OilError::Install(format!("bad public key: {e}")))?;
 
     // Verify PKCS#1 v1.5 signature using the correct hash
-    let sig = Signature::try_from(sig_bytes.as_ref())
+    let sig = Signature::try_from(sig_bytes)
         .map_err(|e| OilError::Install(format!("bad signature bytes: {e}")))?;
 
     if sig_alg == OID_RSA_SHA256 {
         let vk = pkcs1v15::VerifyingKey::<Sha256>::new_unprefixed(pubkey);
         vk.verify_prehash(&prehash, &sig)
-            .map_err(|e| verification_failed(e))
+            .map_err(verification_failed)
     } else if sig_alg == OID_RSA_SHA1 {
         let vk = pkcs1v15::VerifyingKey::<Sha1>::new_unprefixed(pubkey);
         vk.verify_prehash(&prehash, &sig)
-            .map_err(|e| verification_failed(e))
+            .map_err(verification_failed)
     } else {
         Err(OilError::Install(
             "unsupported RSA signature algorithm".into(),


### PR DESCRIPTION
🎯 **What:** Removed the `user` and `global` arguments from the `Install` command in `system/oil/src/main.rs`. Also ran `cargo clippy --fix` to address some minor linting warnings like redundant closures and unnecessary references.
💡 **Why:** These arguments were not implemented and just ignored, so removing them cleans up the codebase and avoids misleading users into thinking they have an effect.
✅ **Verification:** Verified by running `cargo check`, `cargo test`, and `cargo clippy` inside `system/oil` which all pass. Code review has been completed and approved.
✨ **Result:** A cleaner codebase with no unused/dead CLI arguments and fewer clippy warnings.

---
*PR created automatically by Jules for task [6343441550549473480](https://jules.google.com/task/6343441550549473480) started by @undivisible*