### PR TITLE
🧹 Handle `modprobe` results during initialization

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -1,0 +1,39 @@
+// Alpenglow Rust init — replaces the shell /init script
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+fn main() {
+    run("mount", &["-t", "proc", "proc", "/proc"]);
+    run("mount", &["-t", "sysfs", "sysfs", "/sys"]);
+    run("mount", &["-t", "devtmpfs", "devtmpfs", "/dev"]);
+    for d in &["/run", "/dev/shm", "/tmp", "/state", "/sysroot"] {
+        let _ = std::fs::create_dir_all(d);
+    }
+    run("mount", &["-t", "tmpfs", "tmpfs", "/run"]);
+    run("mount", &["-t", "tmpfs", "-o", "mode=1777,size=256m", "tmpfs", "/dev/shm"]);
+    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    let _ = std::fs::create_dir_all("/run/user/0");
+    let _ = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700));
+    for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
+        match Command::new("modprobe").arg(m).status() {
+            Ok(status) if !status.success() => {
+                eprintln!("init: modprobe {} failed with status: {}", m, status);
+            }
+            Err(e) => {
+                eprintln!("init: failed to execute modprobe {}: {}", m, e);
+            }
+            _ => {}
+        }
+    }
+    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    let err = Command::new("/sbin/dinit")
+        .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
+        .exec();
+    eprintln!("init: dinit exec failed: {}", err);
+    let _ = Command::new("/bin/sh").exec();
+}
+fn run(prog: &str, args: &[&str]) {
+    if let Err(e) = Command::new(prog).args(args).status() {
+        eprintln!("init: {} failed: {}", prog, e);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Handled the previously unhandled `Result` when calling `modprobe` in `initramfs/init.rs` to ensure any errors are logged to `stderr`.

💡 **Why:** Silently ignoring errors during module loading makes debugging boot issues difficult. Logging these errors gives immediate visibility into missing drivers or failed initialization steps.

✅ **Verification:** Verified with `rustc --edition=2021 system/backends/appliance/initramfs/init.rs` to ensure correct compilation without syntax errors. The logic preserves existing functionality (does not halt execution on error) while properly reporting both command execution errors and non-zero exit codes.

✨ **Result:** Enhanced boot-time debuggability and a cleaner, more robust initialization script.

---
*PR created automatically by Jules for task [9778246088834754196](https://jules.google.com/task/9778246088834754196) started by @undivisible*