### PR TITLE
🧹 [Code Health] Extract run_command match arms into separate functions

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -82,153 +82,162 @@ fn main() {
 
 fn run_command(cmd: Commands) -> Result<()> {
     match cmd {
-        Commands::Search { query } => {
-            let registry = system::registry::apk::ApkRegistry::alpine_default();
-            let index = registry.load()?;
-            let q = query.to_lowercase();
-            let mut results: Vec<_> = index
-                .packages
-                .iter()
-                .filter(|p| {
-                    p.name.to_lowercase().contains(&q) || p.description.to_lowercase().contains(&q)
-                })
-                .collect();
-            results.sort_by(|a, b| a.name.cmp(&b.name));
-            for pkg in &results {
-                println!("{:<20} {}", pkg.name, pkg.version);
-            }
-            Ok(())
-        }
-        Commands::Info { formula } => {
-            let registry = system::registry::apk::ApkRegistry::alpine_default();
-            let index = registry.load()?;
-            match index.find(&formula) {
-                Some(pkg) => {
-                    println!("Name: {}", pkg.name);
-                    println!("Version: {}", pkg.version);
-                    println!("Description: {}", pkg.description);
-                    println!("URL: {}", pkg.download_url);
-                    println!("Depends: {}", pkg.depends.join(", "));
-                }
-                None => return Err(error::OilError::FormulaNotFound(formula)),
-            }
-            Ok(())
-        }
+        Commands::Search { query } => run_search(query),
+        Commands::Info { formula } => run_info(formula),
         Commands::Install {
             packages,
             dry_run,
             user,
             global,
-        } => {
-            let _ = (user, global);
-            let registry = system::registry::apk::ApkRegistry::alpine_default();
-            let index = registry.load()?;
-            let mut state = install::InstallState::new()?;
-            for name in &packages {
-                let pkg = index
-                    .find(name)
-                    .ok_or_else(|| error::OilError::FormulaNotFound(name.clone()))?;
-                if dry_run {
-                    println!("Would install {} {}", pkg.name, pkg.version);
-                } else {
-                    let dest = std::path::PathBuf::from("/usr/local");
-                    install_package(pkg, &dest)?;
-                    state.mark_installed(&pkg.name, Some(pkg.version.clone()));
-                    println!("Installed {} {}", pkg.name, pkg.version);
-                }
-            }
-            if !dry_run {
-                state.save()?;
-            }
-            Ok(())
+        } => run_install(packages, dry_run, user, global),
+        Commands::Uninstall { formulae, all } => run_uninstall(formulae, all),
+        Commands::Reinstall { packages, all } => run_reinstall(packages, all),
+        Commands::Upgrade { packages, dry_run } => run_upgrade(packages, dry_run),
+        Commands::Outdated => run_outdated(),
+    }
+}
+
+fn run_search(query: String) -> Result<()> {
+    let registry = system::registry::apk::ApkRegistry::alpine_default();
+    let index = registry.load()?;
+    let q = query.to_lowercase();
+    let mut results: Vec<_> = index
+        .packages
+        .iter()
+        .filter(|p| p.name.to_lowercase().contains(&q) || p.description.to_lowercase().contains(&q))
+        .collect();
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    for pkg in &results {
+        println!("{:<20} {}", pkg.name, pkg.version);
+    }
+    Ok(())
+}
+
+fn run_info(formula: String) -> Result<()> {
+    let registry = system::registry::apk::ApkRegistry::alpine_default();
+    let index = registry.load()?;
+    match index.find(&formula) {
+        Some(pkg) => {
+            println!("Name: {}", pkg.name);
+            println!("Version: {}", pkg.version);
+            println!("Description: {}", pkg.description);
+            println!("URL: {}", pkg.download_url);
+            println!("Depends: {}", pkg.depends.join(", "));
         }
-        Commands::Uninstall { formulae, all } => {
-            let mut state = install::InstallState::new()?;
-            if all {
-                state.clear();
-            } else {
-                for name in &formulae {
-                    state.remove(name)?;
-                }
-            }
-            state.save()?;
-            Ok(())
-        }
-        Commands::Reinstall { packages, all } => {
-            let mut state = install::InstallState::new()?;
-            let names: Vec<String> = if all {
-                state.load()?.into_keys().collect()
-            } else {
-                packages
-            };
-            for name in &names {
-                if let Some(_pkg) = state.get(name) {
-                    let registry = system::registry::apk::ApkRegistry::alpine_default();
-                    let index = registry.load()?;
-                    if let Some(latest) = index.find(&name) {
-                        let dest = std::path::PathBuf::from("/usr/local");
-                        install_package(latest, &dest)?;
-                        state.mark_installed(&name, Some(latest.version.clone()));
-                        println!("Reinstalled {name} {}", latest.version);
-                    }
-                }
-            }
-            state.save()?;
-            Ok(())
-        }
-        Commands::Upgrade { packages, dry_run } => {
-            let mut state = install::InstallState::new()?;
-            let installed = state.load()?;
-            let registry = system::registry::apk::ApkRegistry::alpine_default();
-            let index = registry.load()?;
-            let targets: Vec<String> = if packages.is_empty() {
-                installed.keys().cloned().collect()
-            } else {
-                packages
-            };
-            for name in &targets {
-                if let Some(current) = installed.get(name) {
-                    if current.pinned {
-                        continue;
-                    }
-                    if let Some(latest) = index.find(name) {
-                        if &latest.version != &current.version {
-                            if dry_run {
-                                println!(
-                                    "Would upgrade {name}: {} → {}",
-                                    &current.version, &latest.version
-                                );
-                            } else {
-                                let dest = std::path::PathBuf::from("/usr/local");
-                                install_package(latest, &dest)?;
-                                state.mark_installed(name, Some(latest.version.clone()));
-                                println!(
-                                    "Upgraded {name}: {} → {}",
-                                    current.version, latest.version
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-            state.save()?;
-            Ok(())
-        }
-        Commands::Outdated => {
-            let state = install::InstallState::new()?;
-            let installed = state.load()?;
-            let registry = system::registry::apk::ApkRegistry::alpine_default();
-            let index = registry.load()?;
-            for (name, pkg) in &installed {
-                if let Some(latest) = index.find(name) {
-                    if latest.version != pkg.version {
-                        println!("{} {} -> {}", name, pkg.version, latest.version);
-                    }
-                }
-            }
-            Ok(())
+        None => return Err(error::OilError::FormulaNotFound(formula)),
+    }
+    Ok(())
+}
+
+fn run_install(packages: Vec<String>, dry_run: bool, user: bool, global: bool) -> Result<()> {
+    let _ = (user, global);
+    let registry = system::registry::apk::ApkRegistry::alpine_default();
+    let index = registry.load()?;
+    let mut state = install::InstallState::new()?;
+    for name in &packages {
+        let pkg = index
+            .find(name)
+            .ok_or_else(|| error::OilError::FormulaNotFound(name.clone()))?;
+        if dry_run {
+            println!("Would install {} {}", pkg.name, pkg.version);
+        } else {
+            let dest = std::path::PathBuf::from("/usr/local");
+            install_package(pkg, &dest)?;
+            state.mark_installed(&pkg.name, Some(pkg.version.clone()));
+            println!("Installed {} {}", pkg.name, pkg.version);
         }
     }
+    if !dry_run {
+        state.save()?;
+    }
+    Ok(())
+}
+
+fn run_uninstall(formulae: Vec<String>, all: bool) -> Result<()> {
+    let mut state = install::InstallState::new()?;
+    if all {
+        state.clear();
+    } else {
+        for name in &formulae {
+            state.remove(name)?;
+        }
+    }
+    state.save()?;
+    Ok(())
+}
+
+fn run_reinstall(packages: Vec<String>, all: bool) -> Result<()> {
+    let mut state = install::InstallState::new()?;
+    let names: Vec<String> = if all {
+        state.load()?.into_keys().collect()
+    } else {
+        packages
+    };
+    for name in &names {
+        if let Some(_pkg) = state.get(name) {
+            let registry = system::registry::apk::ApkRegistry::alpine_default();
+            let index = registry.load()?;
+            if let Some(latest) = index.find(&name) {
+                let dest = std::path::PathBuf::from("/usr/local");
+                install_package(latest, &dest)?;
+                state.mark_installed(&name, Some(latest.version.clone()));
+                println!("Reinstalled {name} {}", latest.version);
+            }
+        }
+    }
+    state.save()?;
+    Ok(())
+}
+
+fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
+    let mut state = install::InstallState::new()?;
+    let installed = state.load()?;
+    let registry = system::registry::apk::ApkRegistry::alpine_default();
+    let index = registry.load()?;
+    let targets: Vec<String> = if packages.is_empty() {
+        installed.keys().cloned().collect()
+    } else {
+        packages
+    };
+    for name in &targets {
+        if let Some(current) = installed.get(name) {
+            if current.pinned {
+                continue;
+            }
+            if let Some(latest) = index.find(name) {
+                if &latest.version != &current.version {
+                    if dry_run {
+                        println!(
+                            "Would upgrade {name}: {} → {}",
+                            &current.version, &latest.version
+                        );
+                    } else {
+                        let dest = std::path::PathBuf::from("/usr/local");
+                        install_package(latest, &dest)?;
+                        state.mark_installed(name, Some(latest.version.clone()));
+                        println!("Upgraded {name}: {} → {}", current.version, latest.version);
+                    }
+                }
+            }
+        }
+    }
+    state.save()?;
+    Ok(())
+}
+
+fn run_outdated() -> Result<()> {
+    let state = install::InstallState::new()?;
+    let installed = state.load()?;
+    let registry = system::registry::apk::ApkRegistry::alpine_default();
+    let index = registry.load()?;
+    for (name, pkg) in &installed {
+        if let Some(latest) = index.find(name) {
+            if latest.version != pkg.version {
+                println!("{} {} -> {}", name, pkg.version, latest.version);
+            }
+        }
+    }
+    Ok(())
 }
 
 fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Result<()> {
@@ -255,10 +264,10 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         .map_err(|e| error::OilError::Install(format!("set permissions: {e}")))?;
 
     eprintln!("Extracting {}...", pkg.name);
-    
+
     let result = system::apk_extract::extract_tracked(tmp.path(), dest);
-    
+
     let _ = std::fs::remove_file(tmp.path());
-    
+
     result.map(|_| ())
 }

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -78,7 +78,7 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
 
     let mut starts: Vec<usize> = Vec::new();
     let mut last_pos = 0;
-    
+
     for i in 0..data.len().saturating_sub(1) {
         if data[i] == 0x1f && data[i + 1] == 0x8b {
             if i < last_pos {
@@ -86,13 +86,13 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
             }
             starts.push(i);
             last_pos = i;
-            
+
             if starts.len() >= count {
                 break;
             }
         }
     }
-    
+
     if starts.len() < count {
         return Err(OilError::Install(format!(
             "APK has {} gzip streams, expected {count}",
@@ -102,14 +102,14 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
 
     let mut out = Vec::with_capacity(count);
     let mut total_decompressed: usize = 0;
-    
+
     for i in 0..count {
         let slice = &data[starts[i]..];
         let mut decoder = flate2::read::GzDecoder::new(slice);
         let mut buf = Vec::new();
-        
+
         decoder.read_to_end(&mut buf)?;
-        
+
         if buf.len() > MAX_STREAM_SIZE {
             return Err(OilError::Install(format!(
                 "Stream {} size {} exceeds maximum {}",
@@ -118,19 +118,18 @@ fn split_gzip_streams(data: &[u8], count: usize) -> Result<(Vec<u8>, Vec<u8>, Ve
                 MAX_STREAM_SIZE
             )));
         }
-        
+
         total_decompressed += buf.len();
         if total_decompressed > MAX_TOTAL_SIZE {
             return Err(OilError::Install(format!(
                 "Total decompressed size {} exceeds maximum {}",
-                total_decompressed,
-                MAX_TOTAL_SIZE
+                total_decompressed, MAX_TOTAL_SIZE
             )));
         }
-        
+
         out.push(buf);
     }
-    
+
     Ok((out.remove(0), out.remove(0), out.remove(0)))
 }
 


### PR DESCRIPTION
🎯 **What:** The `run_command` function in `system/oil/src/main.rs` was overly long and complex, containing the full logic for every CLI command in a single match statement. I extracted each match arm into a separate, clearly named helper function (e.g., `run_search`, `run_install`, `run_outdated`).
💡 **Why:** This greatly improves the readability and maintainability of the code. `run_command` is now a simple routing function, making it easier to understand the high-level flow and isolate changes to individual commands.
✅ **Verification:** I ran `cargo check`, `cargo fmt`, and `cargo test` in the `system/oil` directory to confirm that the refactoring is safe, the project compiles successfully, and all existing functionality remains intact.
✨ **Result:** A cleaner, more modular `main.rs` file that follows better software engineering practices.

---
*PR created automatically by Jules for task [13587758024866946423](https://jules.google.com/task/13587758024866946423) started by @undivisible*