### PR TITLE
🔒 Fix Path Traversal in APK Extractor

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -168,6 +168,7 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
         }
 
         let stripped = entry_str.strip_prefix("./").unwrap_or(&entry_str);
+        let stripped = stripped.trim_start_matches('/');
         if stripped.is_empty() || stripped.contains("..") {
             continue;
         }
@@ -207,6 +208,10 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             let mut entry = entry_?;
             let path = entry.path()?.to_string_lossy().to_string();
             let stripped = path.strip_prefix("./").unwrap_or(&path);
+            let stripped = stripped.trim_start_matches('/');
+            if stripped.is_empty() || stripped.contains("..") {
+                continue;
+            }
             let dest = dest_dir.join(stripped);
             if let Some(parent) = dest.parent() {
                 std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
🎯 **What:** Path traversal vulnerability in APK extractor via `PathBuf::join` with absolute paths.

⚠️ **Risk:** A malicious APK package could extract files outside the intended installation directory (e.g., `/etc/passwd`), potentially leading to arbitrary code execution or system compromise.

🛡️ **Solution:** Stripped leading slashes from archive paths before joining them with the destination directory, forcing all paths to be relative. I applied this fix to both loops processing extraction within `system/oil/src/system/extractor/apk.rs`. I also added the `..` prevention check to the second loop to prevent directory traversal up out of the extracted directory.

---
*PR created automatically by Jules for task [15725571876383182373](https://jules.google.com/task/15725571876383182373) started by @undivisible*