### PR TITLE
🧹 [code health] Handle unhandled Result during early boot setup in init.rs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -1,0 +1,37 @@
+// Alpenglow Rust init — replaces the shell /init script
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+fn main() {
+    run("mount", &["-t", "proc", "proc", "/proc"]);
+    run("mount", &["-t", "sysfs", "sysfs", "/sys"]);
+    run("mount", &["-t", "devtmpfs", "devtmpfs", "/dev"]);
+    for d in &["/run", "/dev/shm", "/tmp", "/state", "/sysroot"] {
+        if let Err(e) = std::fs::create_dir_all(d) {
+            eprintln!("init: failed to create directory {}: {}", d, e);
+        }
+    }
+    run("mount", &["-t", "tmpfs", "tmpfs", "/run"]);
+    run("mount", &["-t", "tmpfs", "-o", "mode=1777,size=256m", "tmpfs", "/dev/shm"]);
+    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    if let Err(e) = std::fs::create_dir_all("/run/user/0") {
+        eprintln!("init: failed to create directory /run/user/0: {}", e);
+    }
+    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+        eprintln!("init: failed to set permissions for /run/user/0: {}", e);
+    }
+    for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
+        let _ = Command::new("modprobe").arg(m).status();
+    }
+    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    let err = Command::new("/sbin/dinit")
+        .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
+        .exec();
+    eprintln!("init: dinit exec failed: {}", err);
+    let _ = Command::new("/bin/sh").exec();
+}
+fn run(prog: &str, args: &[&str]) {
+    if let Err(e) = Command::new(prog).args(args).status() {
+        eprintln!("init: {} failed: {}", prog, e);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Added error handling for `std::fs::create_dir_all` and `std::fs::set_permissions` in `system/backends/appliance/initramfs/init.rs`. Errors are now logged using `eprintln!` instead of being silently ignored.

💡 **Why:** How this improves maintainability
Ignoring errors during early boot setup makes debugging difficult. Logging the errors improves observability without unnecessarily halting the boot process.

✅ **Verification:** How you confirmed the change is safe
Ran `cargo check`, `cargo test`, and `./scripts/ci-rust-core.sh` to ensure no functionality is broken.

✨ **Result:** The improvement achieved
Improved code health and debuggability in the init script.

---
*PR created automatically by Jules for task [6929711287509984037](https://jules.google.com/task/6929711287509984037) started by @undivisible*