### PR TITLE
🔒 Fix Path Traversal in APK Extractor

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -167,7 +167,7 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             continue;
         }
 
-        let stripped = entry_str.strip_prefix("./").unwrap_or(&entry_str);
+        let stripped = entry_str.strip_prefix("./").unwrap_or(&entry_str).trim_start_matches('/');
         if stripped.is_empty() || stripped.contains("..") {
             continue;
         }
@@ -206,7 +206,7 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
         for entry_ in archive.entries()? {
             let mut entry = entry_?;
             let path = entry.path()?.to_string_lossy().to_string();
-            let stripped = path.strip_prefix("./").unwrap_or(&path);
+            let stripped = path.strip_prefix("./").unwrap_or(&path).trim_start_matches('/');
             let dest = dest_dir.join(stripped);
             if let Some(parent) = dest.parent() {
                 std::fs::create_dir_all(parent)?;


### PR DESCRIPTION
🎯 **What:** Fixed a path traversal vulnerability in the `.apk` package extraction process where archive entries with absolute paths (starting with `/`) could bypass the destination directory logic.
⚠️ **Risk:** High. If an attacker provided a malicious `.apk` archive, or if a repository was compromised, files could be written outside the intended extraction path. This could allow an attacker to overwrite critical system files (e.g., `/etc/passwd`) as a privileged user, leading to a full system compromise.
🛡️ **Solution:** Added a `.trim_start_matches('/')` call to strip any leading slashes from extracted paths in both the primary extraction loop and the hard links loop. This correctly converts any absolute paths embedded in the archive into relative paths before they are joined with the target destination directory, preventing the `PathBuf::join` function from discarding the base directory.

---
*PR created automatically by Jules for task [6847368299277645942](https://jules.google.com/task/6847368299277645942) started by @undivisible*