### PR TITLE
🧹 [code health improvement] Remove obsolete 'ponytail' tag comment in system/oil/src/main.rs

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -163,7 +163,6 @@ fn run_reinstall(packages: Vec<String>, all: bool) -> Result<()> {
     } else {
         packages
     };
-    // ponytail: hoist registry load out of loop — was N+1
     let registry = system::registry::apk::ApkRegistry::alpine_default();
     let index = registry.load()?;
     for name in &names {


### PR DESCRIPTION
🎯 **What:** Removed the `// ponytail: hoist registry load out of loop — was N+1` comment in `system/oil/src/main.rs`.
💡 **Why:** The comment served as an internal marker for a performance optimization that had already been implemented. Removing it cleans up the file and standardizes our code comments, improving readability.
✅ **Verification:** Verified by running `cargo test --manifest-path system/oil/Cargo.toml` which passed all 21 unit tests. No behavior was changed.
✨ **Result:** A cleaner codebase with no obsolete internal "ponytail" markers.

---
*PR created automatically by Jules for task [1660473229643968536](https://jules.google.com/task/1660473229643968536) started by @undivisible*