### PR TITLE
🔒 Fix TOCTOU vulnerability in temporary file handling

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -5,8 +5,7 @@ mod system;
 
 use clap::{Parser, Subcommand};
 use error::Result;
-use std::io::Read;
-use std::os::unix::fs::PermissionsExt;
+use std::io::{Read, Write};
 use std::path::Path;
 
 #[derive(Parser)]
@@ -248,14 +247,11 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         .read_to_end(&mut data)
         .map_err(|e| error::OilError::Install(format!("read failed for {}: {e}", pkg.name)))?;
 
-    let tmp = tempfile::NamedTempFile::new()
+    let mut tmp = tempfile::NamedTempFile::new()
         .map_err(|e| error::OilError::Install(format!("temp file: {e}")))?;
 
-    std::fs::write(tmp.path(), &data)
+    tmp.write_all(&data)
         .map_err(|e| error::OilError::Install(format!("write temp: {e}")))?;
-
-    std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o600))
-        .map_err(|e| error::OilError::Install(format!("set permissions: {e}")))?;
 
     eprintln!("Extracting {}...", pkg.name);
 


### PR DESCRIPTION
🎯 **What:** Fixed a TOCTOU vulnerability in `system/oil/src/main.rs` that involved writing data to a temporary file using its path, followed by a separate path-based `set_permissions` call.

⚠️ **Risk:** An attacker could exploit the path-based race condition between writing the file and securely setting its permissions, potentially resulting in unauthorized file access or modification.

🛡️ **Solution:** Swapped `std::fs::write(tmp.path(), ...)` with `tmp.write_all(...)` to write directly to the safe file descriptor provided by `tempfile::NamedTempFile`. Since `tempfile` ensures safe default permissions (`0o600`), the `set_permissions` call and the vulnerability were successfully removed.

---
*PR created automatically by Jules for task [6998729045674902867](https://jules.google.com/task/6998729045674902867) started by @undivisible*