### PR TITLE
🧹 [code health improvement] Replace unwrap with expect in apk.rs tests

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -234,8 +234,8 @@ mod tests {
 
     fn create_gz_stream(data: &[u8]) -> Vec<u8> {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(data).unwrap();
-        encoder.finish().unwrap()
+        encoder.write_all(data).expect("Failed to write data to gzip encoder");
+        encoder.finish().expect("Failed to finish gzip encoding")
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced `unwrap()` calls with `.expect()` in the `create_gz_stream` test helper function within `system/oil/src/system/extractor/apk.rs`.

💡 **Why:** How this improves maintainability
Using `expect` with descriptive error messages clarifies test failures and improves test diagnostics by explicitly stating what operation failed when writing to or finishing the gzip encoder.

✅ **Verification:** How you confirmed the change is safe
Ran the core Rust test suite locally using `cd system/oil && cargo test` and the full continuous integration checks with `./scripts/ci-rust-core.sh`. All tests pass successfully, confirming that test logic remains unchanged while diagnostics are improved.

✨ **Result:** The improvement achieved
Test failures from gzip stream creation will now print a specific error message, aiding in faster debugging without altering any production code behavior.

---
*PR created automatically by Jules for task [5674556528223815758](https://jules.google.com/task/5674556528223815758) started by @undivisible*