### PR TITLE
🧹 Remove resolved ponytail optimization comment in oil

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -163,7 +163,6 @@ fn run_reinstall(packages: Vec<String>, all: bool) -> Result<()> {
     } else {
         packages
     };
-    // ponytail: hoist registry load out of loop — was N+1
     let registry = system::registry::apk::ApkRegistry::alpine_default();
     let index = registry.load()?;
     for name in &names {


### PR DESCRIPTION
🎯 **What:** Removed the obsolete `// ponytail: hoist registry load out of loop — was N+1` comment from `system/oil/src/main.rs`.
💡 **Why:** The optimization mentioned in the comment has already been implemented, making the comment redundant. Removing it improves readability and helps standardize the codebase comments.
✅ **Verification:** Verified by checking the git diff to ensure only the comment was removed. Also ran `cargo test -p oil --offline` to ensure the compilation and tests still pass. Code review approved the correctness and safety of the change.
✨ **Result:** The codebase is slightly cleaner and more maintainable with the removal of this outdated marker.

---
*PR created automatically by Jules for task [49245657483798414](https://jules.google.com/task/49245657483798414) started by @undivisible*