### PR TITLE
🧪 [tests] Add formatting and conversion tests for OilError

### DIFF
--- a/system/oil/src/error.rs
+++ b/system/oil/src/error.rs
@@ -54,3 +54,55 @@ impl From<ureq::Error> for OilError {
 }
 
 pub type Result<T> = std::result::Result<T, OilError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(
+            OilError::Http("404 Not Found".to_string()).to_string(),
+            "HTTP error: 404 Not Found"
+        );
+        assert_eq!(
+            OilError::FormulaNotFound("curl".to_string()).to_string(),
+            "formula not found: curl"
+        );
+        assert_eq!(
+            OilError::ChecksumMismatch {
+                expected: "abc".to_string(),
+                actual: "def".to_string()
+            }
+            .to_string(),
+            "checksum mismatch: expected abc, got def"
+        );
+        assert_eq!(
+            OilError::Install("install failed".to_string()).to_string(),
+            "install failed"
+        );
+    }
+
+    #[test]
+    fn test_from_and_source() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
+        let oil_io: OilError = io_err.into();
+        assert!(oil_io.to_string().starts_with("I/O error:"));
+        assert!(oil_io.source().is_some());
+
+        let json_err = serde_json::from_str::<serde_json::Value>("{ invalid").unwrap_err();
+        let oil_json: OilError = json_err.into();
+        assert!(oil_json.to_string().starts_with("JSON error:"));
+        assert!(oil_json.source().is_some());
+
+        let http_err = ureq::get("invalid://url").call().unwrap_err();
+        let oil_http: OilError = http_err.into();
+        assert!(oil_http.to_string().starts_with("HTTP error:"));
+        // Http variants don't provide a source
+        assert!(oil_http.source().is_none());
+
+        let install_err = OilError::Install("msg".to_string());
+        assert!(install_err.source().is_none());
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap regarding `OilError` representations, formatting via `fmt::Display`, and type conversions via `From` in `system/oil/src/error.rs` has been addressed.
📊 **Coverage:** The test suite now explicitly covers error string formatting outputs (`test_display`), as well as conversions (`From`) and standard library Error sources (`Error::source`) involving I/O, JSON, and network (ureq) failures (`test_from_and_source`).
✨ **Result:** Test coverage significantly improved for base primitives, increasing confidence in future refactoring of error handling flows.

---
*PR created automatically by Jules for task [471053691606509833](https://jules.google.com/task/471053691606509833) started by @undivisible*