### PR TITLE
🧪 Add tests for install.rs state management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,6 +634,7 @@ dependencies = [
  "der",
  "flate2",
  "hex",
+ "lazy_static",
  "rsa",
  "serde",
  "serde_json",

--- a/system/oil/Cargo.toml
+++ b/system/oil/Cargo.toml
@@ -25,3 +25,4 @@ signature = "2"
 signal-hook = "0.3"
 clap = { version = "4", features = ["derive"] }
 tempfile = "3"
+lazy_static = "1.5.0"

--- a/system/oil/src/install.rs
+++ b/system/oil/src/install.rs
@@ -83,3 +83,127 @@ impl InstallState {
         self.packages.get(name).cloned()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // A static mutex to serialize access to the $HOME environment variable during tests
+    lazy_static::lazy_static! {
+        static ref ENV_LOCK: Mutex<()> = Mutex::new(());
+    }
+
+    struct EnvGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        original_home: Option<std::ffi::OsString>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let lock = ENV_LOCK.lock().expect("Failed to acquire ENV_LOCK");
+            let original_home = std::env::var_os("HOME");
+            Self {
+                _lock: lock,
+                original_home,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_state_path_no_home() -> Result<()> {
+        let _guard = EnvGuard::new();
+        std::env::remove_var("HOME");
+
+        let result = state_path();
+        assert!(result.is_err(), "Expected error when HOME is not set");
+        match result {
+            Err(crate::error::OilError::Install(msg)) => {
+                assert_eq!(msg, "$HOME not set");
+            }
+            _ => panic!("Expected OilError::Install"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_state_path_with_home() -> Result<()> {
+        let _guard = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        std::env::set_var("HOME", temp_dir.path());
+
+        let result = state_path().expect("Expected valid state path");
+        assert_eq!(result, temp_dir.path().join(".oil").join("installed.json"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_install_state_new() -> Result<()> {
+        let _guard = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        std::env::set_var("HOME", temp_dir.path());
+
+        let state = InstallState::new().expect("Failed to create new InstallState");
+        assert!(state.packages.is_empty(), "New state should have empty packages");
+        Ok(())
+    }
+
+    #[test]
+    fn test_install_state_save_load() -> Result<()> {
+        let _guard = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        std::env::set_var("HOME", temp_dir.path());
+
+        let mut state = InstallState::new().expect("Failed to create new InstallState");
+        state.mark_installed("pkg-a", Some("1.0.0"));
+        state.mark_installed("pkg-b", None);
+        state.save().expect("Failed to save state");
+
+        let loaded_state = InstallState::new().expect("Failed to load InstallState");
+
+        let pkg_a = loaded_state.get("pkg-a").expect("pkg-a should exist");
+        assert_eq!(pkg_a.name, "pkg-a");
+        assert_eq!(pkg_a.version, "1.0.0");
+
+        let pkg_b = loaded_state.get("pkg-b").expect("pkg-b should exist");
+        assert_eq!(pkg_b.name, "pkg-b");
+        assert_eq!(pkg_b.version, "");
+        Ok(())
+    }
+
+    #[test]
+    fn test_install_state_operations() -> Result<()> {
+        let _guard = EnvGuard::new();
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        std::env::set_var("HOME", temp_dir.path());
+
+        let mut state = InstallState::new().expect("Failed to create new InstallState");
+
+        state.mark_installed("pkg-c", Some("2.0.0"));
+        let pkg = state.get("pkg-c").expect("pkg-c should exist");
+        assert_eq!(pkg.name, "pkg-c");
+        assert_eq!(pkg.version, "2.0.0");
+
+        state.mark_installed("pkg-c", Some("2.1.0"));
+        let pkg = state.get("pkg-c").expect("pkg-c should exist and be updated");
+        assert_eq!(pkg.version, "2.1.0");
+
+        state.remove("pkg-c").expect("Failed to remove pkg-c");
+        assert!(state.get("pkg-c").is_none(), "pkg-c should be removed");
+
+        state.mark_installed("pkg-d", Some("3.0.0"));
+        state.clear();
+        assert!(state.packages.is_empty(), "State should be empty after clear");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap in `install.rs` state management logic has been addressed. Tests are now correctly validating the behavior of `state_path()` under different environment conditions and `InstallState` operations while preventing race conditions by leveraging a lock on environment variables.

📊 **Coverage:** Scenarios covered include:
- `state_path()` error when `$HOME` is not set
- `state_path()` correctly deriving `.oil/installed.json` when `$HOME` is present
- `InstallState::new()` correctly initializes a new install state
- `InstallState::save()` and `InstallState::load()` effectively round-trips state
- `mark_installed`, `remove`, `clear` and `get` operations on `InstallState`

✨ **Result:** Test coverage for the installation state tracking mechanism has significantly improved, providing safety guarantees when manipulating packages state file safely locking modifications to environment variables when multiple tests run.

---
*PR created automatically by Jules for task [468994307164584023](https://jules.google.com/task/468994307164584023) started by @undivisible*