### PR TITLE
🧪 Add edge case test for complex dependency names

### DIFF
--- a/system/oil/src/system/registry/mod.rs
+++ b/system/oil/src/system/registry/mod.rs
@@ -53,6 +53,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_dep_name_complex_edge_cases() {
+        assert_eq!(parse_dep_name(""), "");
+        assert_eq!(parse_dep_name("   "), "");
+        assert_eq!(parse_dep_name(">=1.0.0"), "");
+        assert_eq!(parse_dep_name("pkg=1.0=2.0"), "pkg");
+        assert_eq!(parse_dep_name("so:libssl.so.3"), "so:libssl.so.3");
+        assert_eq!(parse_dep_name("cmd:bash"), "cmd:bash");
+        assert_eq!(parse_dep_name("  pkg  "), "pkg");
+    }
+
+    #[test]
     fn test_package_index_find_by_name() {
         let index = PackageIndex {
             packages: vec![


### PR DESCRIPTION
🎯 **What:** Added tests for the `parse_dep_name` function to cover complex dependency names such as edge cases, prefixes, constraints, and whitespace.
📊 **Coverage:** Now tests for empty strings, whitespace, version constraints without package names (e.g. `>=1.0.0`), multiple equals signs, `so:` prefix, `cmd:` prefix, and surrounding spaces.
✨ **Result:** Enhanced the test suite reliability by ensuring `parse_dep_name` behaves predictably with various unexpected or complex formats, preventing future regressions.

---
*PR created automatically by Jules for task [12155655753798819082](https://jules.google.com/task/12155655753798819082) started by @undivisible*