### PR TITLE
🔒 Fix Unsafe Execution of Downloaded Script in build-rootfs.sh

### DIFF
--- a/system/backends/appliance/scripts/build-rootfs.sh
+++ b/system/backends/appliance/scripts/build-rootfs.sh
@@ -46,7 +46,7 @@ echo ""
 
 if ! command -v "${OIL_CMD}" >/dev/null 2>&1; then
   echo "Oil (${OIL_CMD}) not found." >&2
-  echo "Install Oil first: curl -fsSL https://oil.sh/install.sh | sh" >&2
+  echo "Install Oil first. Please see https://oil.sh/ for secure installation instructions." >&2
   exit 1
 fi
 


### PR DESCRIPTION
🎯 **What:** Modified the error message in build-rootfs.sh to remove the insecure `curl | sh` instruction.
⚠️ **Risk:** Piping a downloaded script directly into a shell can lead to arbitrary code execution if the network connection is intercepted or the server is compromised.
🛡️ **Solution:** Replaced the unsafe command with a message directing users to the official documentation for secure installation instructions.

---
*PR created automatically by Jules for task [55011094107689130](https://jules.google.com/task/55011094107689130) started by @undivisible*