### PR TITLE
🧪 Add test for read_snapshot non-existent root edge case

### DIFF
--- a/system/netd/src/lib.rs
+++ b/system/netd/src/lib.rs
@@ -233,6 +233,19 @@ mod tests {
     }
 
     #[test]
+    fn read_snapshot_non_existent_root() {
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "alpenglow-netd-test-nonexistent-{}-{}",
+            std::process::id(),
+            now_unix_ms()
+        ));
+
+        let snapshot = read_snapshot(&path).expect("snapshot should parse gracefully when root does not exist");
+        assert!(snapshot.interfaces.is_empty());
+    }
+
+    #[test]
     fn renders_runtime_state_for_shell_consumers() {
         let snapshot = NetworkSnapshot {
             generated_unix_ms: 123,


### PR DESCRIPTION
🎯 **What:** Added a missing unit test in `read_snapshot` to handle the edge case where the provided sysfs root directory does not exist.
📊 **Coverage:** The `!root.exists()` early-return path is now explicitly tested to ensure an empty snapshot is returned.
✨ **Result:** Increased code coverage and improved confidence in code reliability without relying on manual verification.

---
*PR created automatically by Jules for task [4229284840506683657](https://jules.google.com/task/4229284840506683657) started by @undivisible*