### PR TITLE
🧹 [Code Health] Split run_upgrade into smaller functions

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -271,6 +271,27 @@ fn run_reinstall(packages: Vec<String>, all: bool) -> Result<()> {
     Ok(())
 }
 
+fn compute_upgrades<'a>(
+    targets: &[String],
+    installed: &std::collections::HashMap<String, install::InstalledPackage>,
+    index: &'a system::registry::PackageIndex,
+) -> Vec<(&'a system::registry::PackageMetadata, String)> {
+    let mut upgrades = Vec::new();
+    for name in targets {
+        if let Some(current) = installed.get(name) {
+            if current.pinned {
+                continue;
+            }
+            if let Some(latest) = index.find(name) {
+                if latest.version != current.version {
+                    upgrades.push((latest, current.version.clone()));
+                }
+            }
+        }
+    }
+    upgrades
+}
+
 fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
     let mut state = install::InstallState::new()?;
     let installed = state.load()?;
@@ -281,29 +302,24 @@ fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
     } else {
         packages
     };
-    for name in &targets {
-        if let Some(current) = installed.get(name) {
-            if current.pinned {
-                continue;
-            }
-            if let Some(latest) = index.find(name) {
-                if latest.version != current.version {
-                    if dry_run {
-                        println!(
-                            "Would upgrade {name}: {} → {}",
-                            &current.version, &latest.version
-                        );
-                    } else {
-                        let dest = std::path::PathBuf::from("/usr/local");
-                        install_package(latest, &dest)?;
-                        state.mark_installed(name, Some(latest.version.as_str()));
-                        println!(
-                            "Upgraded {name}: {} → {}",
-                            current.version, latest.version
-                        );
-                    }
-                }
-            }
+
+    let upgrades = compute_upgrades(&targets, &installed, &index);
+
+    for (latest, current_version) in upgrades {
+        let name = &latest.name;
+        if dry_run {
+            println!(
+                "Would upgrade {name}: {} → {}",
+                current_version, latest.version
+            );
+        } else {
+            let dest = std::path::PathBuf::from("/usr/local");
+            install_package(latest, &dest)?;
+            state.mark_installed(name, Some(latest.version.as_str()));
+            println!(
+                "Upgraded {name}: {} → {}",
+                current_version, latest.version
+            );
         }
     }
     state.save()?;
@@ -531,5 +547,81 @@ mod tests {
     fn test_run_install_recipe_missing_file() {
         let result = run_install_recipe(PathBuf::from("/nonexistent/recipe.yml"), true);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compute_upgrades() {
+        use std::collections::HashMap;
+        use crate::install::InstalledPackage;
+        use crate::system::registry::{PackageIndex, PackageMetadata};
+
+        let mut installed = HashMap::new();
+        // Needs upgrade
+        installed.insert("pkg_upgrade".to_string(), InstalledPackage {
+            name: "pkg_upgrade".to_string(),
+            version: "1.0.0".to_string(),
+            install_date: 0,
+            pinned: false,
+        });
+        // Up to date
+        installed.insert("pkg_current".to_string(), InstalledPackage {
+            name: "pkg_current".to_string(),
+            version: "2.0.0".to_string(),
+            install_date: 0,
+            pinned: false,
+        });
+        // Pinned, should be ignored even if out of date
+        installed.insert("pkg_pinned".to_string(), InstalledPackage {
+            name: "pkg_pinned".to_string(),
+            version: "1.0.0".to_string(),
+            install_date: 0,
+            pinned: true,
+        });
+
+        let pkgs = vec![
+            PackageMetadata {
+                name: "pkg_upgrade".to_string(),
+                version: "1.1.0".to_string(),
+                description: "".to_string(),
+                download_url: "".to_string(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec![],
+            },
+            PackageMetadata {
+                name: "pkg_current".to_string(),
+                version: "2.0.0".to_string(),
+                description: "".to_string(),
+                download_url: "".to_string(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec![],
+            },
+            PackageMetadata {
+                name: "pkg_pinned".to_string(),
+                version: "1.1.0".to_string(),
+                description: "".to_string(),
+                download_url: "".to_string(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec![],
+            },
+        ];
+        let index = PackageIndex::new(pkgs);
+        let targets = vec![
+            "pkg_upgrade".to_string(),
+            "pkg_current".to_string(),
+            "pkg_pinned".to_string(),
+        ];
+
+        let upgrades = compute_upgrades(&targets, &installed, &index);
+
+        assert_eq!(upgrades.len(), 1, "Only one package should be upgraded");
+        assert_eq!(upgrades[0].0.name, "pkg_upgrade");
+        assert_eq!(upgrades[0].0.version, "1.1.0");
+        assert_eq!(upgrades[0].1, "1.0.0");
     }
 }


### PR DESCRIPTION
* 🎯 **What:** Extracted the core version checking and upgrade loop logic from `run_upgrade` into a new, pure function called `compute_upgrades`.
* 💡 **Why:** This isolates the logic that determines which packages require an upgrade from the side effects of CLI output and file state management, improving readability and testability.
* ✅ **Verification:** Wrote a new unit test `test_compute_upgrades` to explicitly test the upgrade tracking logic, and ran the full `cargo test` suite in `system/oil` (all 58 tests passed).
* ✨ **Result:** The `run_upgrade` function is now cleaner, focused only on side effects, and the underlying logic is decoupled and fully tested.

---
*PR created automatically by Jules for task [10155205621125817271](https://jules.google.com/task/10155205621125817271) started by @undivisible*