### PR TITLE
🧹 [Refactor extractor tests to return Result instead of unwrap]

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -232,17 +232,17 @@ mod tests {
     use std::io::Write;
     use tempfile::tempdir;
 
-    fn create_gz_stream(data: &[u8]) -> Vec<u8> {
+    fn create_gz_stream(data: &[u8]) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>> {
         let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
-        encoder.write_all(data).expect("Failed to write data to gzip encoder");
-        encoder.finish().expect("Failed to finish gzip encoding")
+        encoder.write_all(data)?;
+        Ok(encoder.finish()?)
     }
 
     #[test]
-    fn test_split_gzip_streams_happy_path() {
-        let stream1 = create_gz_stream(b"stream 1 data");
-        let stream2 = create_gz_stream(b"stream 2 data");
-        let stream3 = create_gz_stream(b"stream 3 data");
+    fn test_split_gzip_streams_happy_path() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let stream1 = create_gz_stream(b"stream 1 data")?;
+        let stream2 = create_gz_stream(b"stream 2 data")?;
+        let stream3 = create_gz_stream(b"stream 3 data")?;
 
         let mut combined = Vec::new();
         combined.extend(&stream1);
@@ -251,89 +251,97 @@ mod tests {
 
         let result = split_gzip_streams(&combined, 3);
         assert!(result.is_ok());
-        let (out1, out2, out3) = result.unwrap();
+        let (out1, out2, out3) = result?;
 
         assert_eq!(out1, b"stream 1 data");
         assert_eq!(out2, b"stream 2 data");
         assert_eq!(out3, b"stream 3 data");
+        Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_too_many_requested() {
-        let stream = create_gz_stream(b"data");
+    fn test_split_gzip_streams_too_many_requested() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let stream = create_gz_stream(b"data")?;
         let result = split_gzip_streams(&stream, 4);
         assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
+        let err_msg = result.expect_err("Expected an error").to_string();
         assert!(err_msg.contains("Requested 4 streams, maximum is 3"), "Unexpected error: {}", err_msg);
+        Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_not_enough_streams() {
-        let stream1 = create_gz_stream(b"data 1");
-        let stream2 = create_gz_stream(b"data 2");
+    fn test_split_gzip_streams_not_enough_streams() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let stream1 = create_gz_stream(b"data 1")?;
+        let stream2 = create_gz_stream(b"data 2")?;
         let mut combined = Vec::new();
         combined.extend(&stream1);
         combined.extend(&stream2);
 
         let result = split_gzip_streams(&combined, 3);
         assert!(result.is_err());
-        let err_msg = result.unwrap_err().to_string();
+        let err_msg = result.expect_err("Expected an error").to_string();
         assert!(err_msg.contains("APK has 2 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_corrupted_gzip() {
-        let mut data = create_gz_stream(b"stream 1 data");
-        data.extend(create_gz_stream(b"stream 2 data"));
-        let mut corrupted_stream = create_gz_stream(b"stream 3 data");
+    fn test_split_gzip_streams_corrupted_gzip() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut data = create_gz_stream(b"stream 1 data")?;
+        data.extend(create_gz_stream(b"stream 2 data")?);
+        let mut corrupted_stream = create_gz_stream(b"stream 3 data")?;
         corrupted_stream.truncate(5);
         data.extend(corrupted_stream);
         let result = split_gzip_streams(&data, 3);
         assert!(result.is_err());
+        Ok(())
     }
 
     #[test]
-    fn test_extract_tracked_missing_file() {
-        let dir = tempdir().unwrap();
+    fn test_extract_tracked_missing_file() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
         let missing_path = dir.path().join("does_not_exist.apk");
         let dest_dir = dir.path().join("dest");
         let result = extract_tracked(&missing_path, &dest_dir);
         assert!(result.is_err());
+        Ok(())
     }
 
     #[test]
-    fn test_extract_signature_info_success() {
+    fn test_extract_signature_info_success() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"dummy signature data";
         header.set_size(data.len() as u64);
         header.set_cksum();
-        tar_builder.append_data(&mut header, ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub", &data[..]).unwrap();
-        let tar_data = tar_builder.into_inner().unwrap();
+        tar_builder.append_data(&mut header, ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub", &data[..])?;
+        let tar_data = tar_builder.into_inner()?;
         let result = extract_signature_info(&tar_data);
         assert!(result.is_some());
-        let (keyname, sig) = result.unwrap();
+        let (keyname, sig) = result.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Missing signature"))?;
         assert_eq!(keyname, "alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub");
         assert_eq!(sig, data);
+        Ok(())
     }
 
     #[test]
-    fn test_extract_signature_info_not_found() {
+    fn test_extract_signature_info_not_found() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"some other file";
         header.set_size(data.len() as u64);
         header.set_cksum();
-        tar_builder.append_data(&mut header, "some_other_file.txt", &data[..]).unwrap();
-        let tar_data = tar_builder.into_inner().unwrap();
+        tar_builder.append_data(&mut header, "some_other_file.txt", &data[..])?;
+        let tar_data = tar_builder.into_inner()?;
         let result = extract_signature_info(&tar_data);
         assert!(result.is_none());
+        Ok(())
     }
 
     #[test]
-    fn test_extract_signature_info_invalid_tar() {
+    fn test_extract_signature_info_invalid_tar() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let invalid_tar_data = b"not a tar file";
         let result = extract_signature_info(invalid_tar_data);
         assert!(result.is_none());
+        Ok(())
     }
 }


### PR DESCRIPTION
🎯 **What:** Replaced `unwrap()` calls with `Result` returning signatures and `?` in `system/oil/src/system/extractor/apk.rs` tests.
💡 **Why:** This makes the test code safer and improves maintainability by failing gracefully rather than panicking on errors.
✅ **Verification:** Verified by running all tests in `system/oil` and ensuring they still pass.
✨ **Result:** Cleaner and safer test functions without hidden panics.

---
*PR created automatically by Jules for task [909578914007882938](https://jules.google.com/task/909578914007882938) started by @undivisible*