### PR TITLE
🔒 Fix: Clear environment variables before dropping to shell in init

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -36,7 +36,7 @@ fn main() {
         .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
         .exec();
     eprintln!("init: dinit exec failed: {}", err);
-    let _ = Command::new("/usr/bin/sh").exec();
+    let _ = Command::new("/usr/bin/sh").env_clear().exec();
 }
 fn run(prog: &str, args: &[&str]) {
     if let Err(e) = Command::new(prog).args(args).status() {


### PR DESCRIPTION
🎯 **What:** Modified the initramfs `init.rs` script to use `.env_clear()` when spawning the fallback `/usr/bin/sh` shell after a `dinit` execution failure.

⚠️ **Risk:** If `dinit` fails to start, the system drops to a rescue shell. Without clearing the environment, this shell inherits all environment variables from the `init` process. This could potentially expose sensitive information gathered during boot or allow an attacker who somehow manipulated the pre-init environment to exploit or confuse the root shell environment.

🛡️ **Solution:** By chaining `.env_clear()` onto the `std::process::Command` builder for the shell, we guarantee that the fallback shell starts with a completely empty environment. This provides a pristine, predictable, and safer execution context for the emergency root shell.

---
*PR created automatically by Jules for task [11007339524477675762](https://jules.google.com/task/11007339524477675762) started by @undivisible*