### PR TITLE
🔒 Fix insecure /tmp directory usage in build scripts

### DIFF
--- a/system/backends/appliance/scripts/build-elogind.sh
+++ b/system/backends/appliance/scripts/build-elogind.sh
@@ -2,12 +2,14 @@
 # Build elogind as static musl binary
 set -eu
 
-OUT_DIR="${1:-/tmp/out}"
+OUT_DIR="${1:-$(mktemp -d)}"
 VERSION="${2:-255.8}"
 
 echo "→ Building elogind ${VERSION}..."
 
-cd /tmp
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cd "$BUILD_DIR"
 curl -fsSL "https://github.com/elogind/elogind/archive/v${VERSION}.tar.gz" -o elogind.tar.gz
 tar -xf elogind.tar.gz
 cd "elogind-${VERSION}"

--- a/system/backends/appliance/scripts/build-foot.sh
+++ b/system/backends/appliance/scripts/build-foot.sh
@@ -2,12 +2,14 @@
 # Build foot (Wayland terminal) as static musl binary
 set -eu
 
-OUT_DIR="${1:-/tmp/out}"
+OUT_DIR="${1:-$(mktemp -d)}"
 VERSION="${2:-1.18.0}"
 
 echo "→ Building foot ${VERSION}..."
 
-cd /tmp
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cd "$BUILD_DIR"
 curl -fsSL "https://codeberg.org/dnkl/foot/archive/v${VERSION}.tar.gz" -o foot.tar.gz
 tar -xf foot.tar.gz
 cd "foot"

--- a/system/backends/appliance/scripts/build-greetd.sh
+++ b/system/backends/appliance/scripts/build-greetd.sh
@@ -2,12 +2,14 @@
 # Build greetd as static musl binary
 set -eu
 
-OUT_DIR="${1:-/tmp/out}"
+OUT_DIR="${1:-$(mktemp -d)}"
 VERSION="${2:-0.10.3}"
 
 echo "→ Building greetd ${VERSION}..."
 
-cd /tmp
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cd "$BUILD_DIR"
 curl -fsSL "https://gitlab.com/mobian1/greetd/-/archive/v${VERSION}/greetd-v${VERSION}.tar.gz" -o greetd.tar.gz
 tar -xf greetd.tar.gz
 cd "greetd-v${VERSION}"

--- a/system/backends/appliance/scripts/build-iwd.sh
+++ b/system/backends/appliance/scripts/build-iwd.sh
@@ -2,12 +2,14 @@
 # Build iwd as static musl binary
 set -eu
 
-OUT_DIR="${1:-/tmp/out}"
+OUT_DIR="${1:-$(mktemp -d)}"
 VERSION="${2:-2.18}"
 
 echo "→ Building iwd ${VERSION}..."
 
-cd /tmp
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cd "$BUILD_DIR"
 curl -fsSL "https://www.kernel.org/pub/linux/network/wireless/iwd-${VERSION}.tar.xz" -o iwd.tar.xz
 tar -xf iwd.tar.xz
 cd "iwd-${VERSION}"

--- a/system/backends/appliance/scripts/build-velox.sh
+++ b/system/backends/appliance/scripts/build-velox.sh
@@ -2,11 +2,13 @@
 # Build velox (Wayland compositor) from source as static musl binary
 set -eu
 
-OUT_DIR="${1:-/tmp/out}"
+OUT_DIR="${1:-$(mktemp -d)}"
 
 echo "→ Building velox..."
 
-cd /tmp
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+cd "$BUILD_DIR"
 git clone --depth=1 https://github.com/velox-rs/velox.git velox-src
 cd velox-src
 


### PR DESCRIPTION
🎯 **What:** Replaced hardcoded insecure temporary directory paths (`/tmp/out` and `/tmp`) with securely generated directories using `mktemp -d` across multiple build scripts (`build-foot.sh`, `build-elogind.sh`, `build-greetd.sh`, `build-iwd.sh`, `build-velox.sh`).
⚠️ **Risk:** An attacker could pre-create these predictable directories or files within `/tmp` to intercept, modify, or poison build artifacts and source code tarballs.
🛡️ **Solution:** Used `mktemp -d` to generate unique, secure temporary directories for both the output directory fallback and the intermediate build workspace. Added an `EXIT` trap to ensure the secure build workspace is cleaned up upon script completion (success or failure).

---
*PR created automatically by Jules for task [17734263237226303901](https://jules.google.com/task/17734263237226303901) started by @undivisible*