### PR TITLE
🧪 Add edge-case tests for wU64 in kernelctl

### DIFF
--- a/system/kernelctl-zig/src/main.zig
+++ b/system/kernelctl-zig/src/main.zig
@@ -260,3 +260,35 @@ test "wU64 does not write on null" {
     };
     return error.ExpectedFileNotFound;
 }
+
+test "wU64 writes zero correctly" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_zero.txt", 0);
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_zero.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("0\n", data);
+}
+
+test "wU64 writes max u64 correctly" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_max.txt", std.math.maxInt(u64));
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_max.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("18446744073709551615\n", data);
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `wU64` helper function to handle 0 and max u64 values.
📊 **Coverage:** Covered edge cases (0 and std.math.maxInt(u64)) to verify correctness and ensure no buffer overflows.
✨ **Result:** Improved reliability and test coverage for cgroups interaction logic in kernelctl.

---
*PR created automatically by Jules for task [4627353202235178093](https://jules.google.com/task/4627353202235178093) started by @undivisible*