### PR TITLE
🔒 Fix insecure temporary file creation in package installation

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -525,7 +525,30 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         .read_to_end(&mut data)
         .map_err(|e| error::OilError::Install(format!("read failed for {}: {e}", pkg.name)))?;
 
-    let mut tmp = tempfile::NamedTempFile::new()
+    let home = std::env::var_os("HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(std::path::PathBuf::from))
+        .ok_or_else(|| error::OilError::Install("HOME or USERPROFILE not set".into()))?;
+
+    let tmp_dir = home.join(".oil").join("tmp");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        std::fs::DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&tmp_dir)
+            .map_err(|e| error::OilError::Install(format!("failed to create secure tmp dir: {e}")))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::create_dir_all(&tmp_dir)
+            .map_err(|e| error::OilError::Install(format!("failed to create secure tmp dir: {e}")))?;
+    }
+
+    let mut tmp = tempfile::Builder::new()
+        .tempfile_in(&tmp_dir)
         .map_err(|e| error::OilError::Install(format!("temp file: {e}")))?;
 
     tmp.write_all(&data)


### PR DESCRIPTION
🎯 **What:**
The vulnerability where downloaded packages are stored in a default temp file instead of a secure, dedicated directory. This could potentially allow arbitrary malicious local users to examine and interfere with downloaded files.

⚠️ **Risk:**
High/Moderate depending on environment. Because files were being stored directly in the default OS temporary path (`/tmp`) without restrictions, any local user might intercept, inspect, or tamper with system packages during the installation process, leading to compromised system security or integrity.

🛡️ **Solution:**
I modified `install_package` in `system/oil/src/main.rs` to securely allocate temporary storage. Specifically, it now resolves the user's `$HOME` (or `$USERPROFILE`), creates an isolated `~/.oil/tmp` directory, and applies strict `0o700` permissions (on UNIX-like OSes). It then explicitly uses `tempfile::Builder::new().tempfile_in(&tmp_dir)` to randomize and allocate the download file securely inside that restricted directory, thus mitigating access by unauthorized users.

---
*PR created automatically by Jules for task [882488141170511192](https://jules.google.com/task/882488141170511192) started by @undivisible*