### PR TITLE
🧪 Add boundary tests for wU64 helper

### DIFF
--- a/system/kernelctl-zig/src/main.zig
+++ b/system/kernelctl-zig/src/main.zig
@@ -260,3 +260,35 @@ test "wU64 does not write on null" {
     };
     return error.ExpectedFileNotFound;
 }
+
+test "wU64 writes correctly with 0" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_zero.txt", 0);
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_zero.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("0\n", data);
+}
+
+test "wU64 writes correctly with max int" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_max.txt", std.math.maxInt(u64));
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_max.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("18446744073709551615\n", data);
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `wU64` helper function in `system/kernelctl-zig/src/main.zig` to improve test coverage.
📊 **Coverage:** Added coverage for boundary values (0 and max u64).
✨ **Result:** Improved test coverage and reliability by verifying buffer limits and stringification logic.

---
*PR created automatically by Jules for task [5820355826899234865](https://jules.google.com/task/5820355826899234865) started by @undivisible*