### PR TITLE
🧪 [Add test for InstallState::load]

### DIFF
--- a/system/oil/src/install.rs
+++ b/system/oil/src/install.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::error::Result;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct InstalledPackage {
     pub name: String,
     pub version: String,
@@ -241,6 +241,8 @@ mod tests {
         let pkg_y = loaded.get("pkg-y").expect("pkg-y should exist in loaded map");
         assert_eq!(pkg_y.name, "pkg-y");
         assert_eq!(pkg_y.version, "2.0.0");
+
+        assert_eq!(loaded, state.packages);
 
         Ok(())
     }


### PR DESCRIPTION
- 🎯 **What:** Improved the test for `InstallState::load` in `system/oil/src/install.rs` to assert equality of the entire returned HashMap.
- 📊 **Coverage:** Covered the happy path by verifying that the loaded `HashMap<String, InstalledPackage>` perfectly matches the internal `packages` HashMap.
- ✨ **Result:** Improved test coverage by adding a complete check that clones match the internal state exactly, while preserving existing assertions to prevent regressions.

---
*PR created automatically by Jules for task [5132227354791299960](https://jules.google.com/task/5132227354791299960) started by @undivisible*