### PR TITLE
🧪 Add tests for write_snapshot in netd

### DIFF
--- a/system/netd/src/lib.rs
+++ b/system/netd/src/lib.rs
@@ -347,6 +347,64 @@ mod tests {
         assert_eq!(env_contents, render_runtime_env(&snapshot));
     }
 
+    #[test]
+    fn write_snapshot_state_json_error() {
+        let fixture = TestSysfs::new();
+        let snapshot = NetworkSnapshot {
+            generated_unix_ms: 123,
+            interfaces: vec![],
+        };
+
+        let state_json = fixture.path().join("out/state_json_dir");
+        fs::create_dir_all(&state_json).expect("should create directory");
+        let runtime_env = fixture.path().join("out/runtime.env");
+
+        let result = write_snapshot(&snapshot, &state_json, &runtime_env);
+        let error = result.expect_err("should return an error when writing to a directory");
+        assert_eq!(error.kind(), io::ErrorKind::IsADirectory);
+    }
+
+    #[test]
+    fn write_snapshot_runtime_env_error() {
+        let fixture = TestSysfs::new();
+        let snapshot = NetworkSnapshot {
+            generated_unix_ms: 123,
+            interfaces: vec![],
+        };
+
+        let state_json = fixture.path().join("out/state.json");
+        let runtime_env = fixture.path().join("out/runtime_env_dir");
+        fs::create_dir_all(&runtime_env).expect("should create directory");
+
+        let result = write_snapshot(&snapshot, &state_json, &runtime_env);
+        let error = result.expect_err("should return an error when writing to a directory");
+        assert_eq!(error.kind(), io::ErrorKind::IsADirectory);
+
+        // Verify that state_json was successfully written before the error
+        assert!(state_json.exists());
+        let json_contents = fs::read_to_string(&state_json)
+            .expect("should read state.json file successfully");
+        assert_eq!(json_contents, render_json(&snapshot));
+    }
+
+    #[test]
+    fn write_snapshot_success() {
+        let fixture = TestSysfs::new();
+        let snapshot = NetworkSnapshot {
+            generated_unix_ms: 123,
+            interfaces: vec![],
+        };
+
+        let state_json = fixture.path().join("out/state.json");
+        let runtime_env = fixture.path().join("out/runtime.env");
+
+        let result = write_snapshot(&snapshot, &state_json, &runtime_env);
+        assert!(result.is_ok(), "write_snapshot should return Ok on success");
+
+        assert!(state_json.exists());
+        assert!(runtime_env.exists());
+    }
+
     struct TestSysfs {
         path: PathBuf,
     }


### PR DESCRIPTION
🎯 **What:** 
Added tests for `write_snapshot` in `system/netd/src/lib.rs` to cover happy paths and error conditions, addressing the testing gap.

📊 **Coverage:**
*   **Happy Path:** `write_snapshot_success` verifies the successful creation of both `state_json` and `runtime_env` files.
*   **Error Condition (state_json):** `write_snapshot_state_json_error` validates that an `io::Error` is correctly propagated if the `state_json` write fails (simulated by providing a directory).
*   **Error Condition (runtime_env):** `write_snapshot_runtime_env_error` verifies that an `io::Error` is propagated if `runtime_env` fails to write, and crucially confirms that `state_json` was successfully written before the error occurred.

✨ **Result:**
Improved test coverage for `write_snapshot`, ensuring reliable file writes and proper error handling.

---
*PR created automatically by Jules for task [6956733853927663563](https://jules.google.com/task/6956733853927663563) started by @undivisible*