### PR TITLE
🧪 Add proper read_snapshot non-existent root edge case test

### DIFF
--- a/system/netd/src/lib.rs
+++ b/system/netd/src/lib.rs
@@ -233,16 +233,20 @@ mod tests {
     }
 
     #[test]
-    fn read_snapshot_non_existent_root() {
+    fn read_snapshot_non_existent_root() -> io::Result<()> {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let mut path = std::env::temp_dir();
         path.push(format!(
-            "alpenglow-netd-test-nonexistent-{}-{}",
+            "alpenglow-netd-test-nonexistent-{}-{}-{}",
             std::process::id(),
-            now_unix_ms()
+            now_unix_ms(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
         ));
 
-        let snapshot = read_snapshot(&path).expect("snapshot should parse gracefully when root does not exist");
+        let snapshot = read_snapshot(&path)?;
         assert!(snapshot.interfaces.is_empty());
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Improved the `read_snapshot_non_existent_root` test to avoid flaky test collisions in parallel test runs (by using `AtomicUsize` for the temporary path) and to properly handle errors by returning `Result` instead of using `.expect()`.
📊 **Coverage:** The `read_snapshot` function is now more reliably tested against a non-existent root directory path.
✨ **Result:** Improved test reliability and proper error handling for the read_snapshot non-existent root edge case.

---
*PR created automatically by Jules for task [2113703450679809770](https://jules.google.com/task/2113703450679809770) started by @undivisible*