### PR TITLE
🔒 Fix insecure directory usage in `build-greetd.sh`

### DIFF
--- a/system/backends/appliance/scripts/build-greetd.sh
+++ b/system/backends/appliance/scripts/build-greetd.sh
@@ -2,7 +2,7 @@
 # Build greetd as static musl binary
 set -eu
 
-OUT_DIR="${1:-/build/out}"
+OUT_DIR="${1:?OUT_DIR must be specified}"
 VERSION="${2:-0.10.3}"
 
 echo "→ Building greetd ${VERSION}..."


### PR DESCRIPTION
🎯 **What:** 
Removed the insecure default fallback `/build/out` (which was historically `/tmp/out` in older contexts and reported in the issue) from `build-greetd.sh`'s `OUT_DIR` variable, changing it to explicitly require the argument using `${1:?OUT_DIR must be specified}`.

⚠️ **Risk:** 
If a build script implicitly falls back to a shared system directory like `/tmp/out` when invoked without arguments, it is vulnerable to symlink attacks, arbitrary file overwrites, and permission escalation by local users who can pre-create the directory or predictably manipulate the output.

🛡️ **Solution:** 
By changing the assignment to `OUT_DIR="${1:?OUT_DIR must be specified}"`, the script will now immediately fail-close if an output directory is not explicitly passed by the caller (such as the `build-all-services.sh` wrapper). This enforces the caller to provide a safe, isolated directory, completely mitigating the risk of defaulting to a shared insecure location.

---
*PR created automatically by Jules for task [12366721991283670734](https://jules.google.com/task/12366721991283670734) started by @undivisible*