### PR TITLE
🧪 [netd] Add error handling tests for write_snapshot

### DIFF
--- a/system/netd/src/lib.rs
+++ b/system/netd/src/lib.rs
@@ -347,6 +347,42 @@ mod tests {
         assert_eq!(env_contents, render_runtime_env(&snapshot));
     }
 
+    #[test]
+    fn write_snapshot_returns_error_if_state_json_write_fails() {
+        let fixture = TestSysfs::new();
+        let snapshot = NetworkSnapshot {
+            generated_unix_ms: 123,
+            interfaces: vec![],
+        };
+
+        let state_json = fixture.path().join("out/state.json");
+        let runtime_env = fixture.path().join("out/runtime.env");
+
+        // Create a directory at the state_json path to cause fs::write to fail
+        fs::create_dir_all(&state_json).unwrap();
+
+        let result = write_snapshot(&snapshot, &state_json, &runtime_env);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn write_snapshot_returns_error_if_runtime_env_write_fails() {
+        let fixture = TestSysfs::new();
+        let snapshot = NetworkSnapshot {
+            generated_unix_ms: 123,
+            interfaces: vec![],
+        };
+
+        let state_json = fixture.path().join("out/state.json");
+        let runtime_env = fixture.path().join("out/runtime.env");
+
+        // Create a directory at the runtime_env path to cause fs::write to fail
+        fs::create_dir_all(&runtime_env).unwrap();
+
+        let result = write_snapshot(&snapshot, &state_json, &runtime_env);
+        assert!(result.is_err());
+    }
+
     struct TestSysfs {
         path: PathBuf,
     }


### PR DESCRIPTION
🎯 **What:** Added missing tests to verify that `write_snapshot` correctly propagates `io::Error` when file writing fails for `state_json` or `runtime_env`.
📊 **Coverage:** Now tests error conditions for writing the json and env output files by exploiting directory paths to simulate write failures.
✨ **Result:** Improved robustness by confirming error propagation on file I/O failures.

---
*PR created automatically by Jules for task [3956785989119535070](https://jules.google.com/task/3956785989119535070) started by @undivisible*