### PR TITLE
🔒 Fix insecure temporary file creation in install_package

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -525,7 +525,26 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         .read_to_end(&mut data)
         .map_err(|e| error::OilError::Install(format!("read failed for {}: {e}", pkg.name)))?;
 
-    let mut tmp = tempfile::NamedTempFile::new()
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+        .ok_or_else(|| error::OilError::Install("Could not determine home directory".into()))?;
+
+    let tmp_dir = home.join(".oil").join("tmp");
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.recursive(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        builder.mode(0o700);
+    }
+
+    builder.create(&tmp_dir)
+        .map_err(|e| error::OilError::Install(format!("failed to create secure tmp dir: {e}")))?;
+
+    let mut tmp = tempfile::Builder::new()
+        .tempfile_in(&tmp_dir)
         .map_err(|e| error::OilError::Install(format!("temp file: {e}")))?;
 
     tmp.write_all(&data)


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the insecure creation of temporary files for downloaded packages using `tempfile::NamedTempFile::new()`, which defaults to the shared system `/tmp` directory.

⚠️ **Risk:** Storing downloaded packages in the default `/tmp` directory exposes them to local TOCTOU (Time-of-Check Time-of-Use) vulnerabilities, symlink attacks, and unauthorized access or modification by other local users.

🛡️ **Solution:** The temporary files are now created within a dedicated `~/.oil/tmp` directory using `tempfile::Builder::new().tempfile_in(&tmp_dir)`. The directory is created with restrictive `0o700` permissions on Unix platforms to ensure it is isolated and secure from other system users.

---
*PR created automatically by Jules for task [14747843851966273808](https://jules.google.com/task/14747843851966273808) started by @undivisible*