### PR TITLE
🔒 Fix vulnerable environment inheritance in initramfs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -12,12 +12,26 @@ fn main() {
         }
     }
     run("mount", &["-t", "tmpfs", "tmpfs", "/run"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777,size=256m", "tmpfs", "/dev/shm"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    run(
+        "mount",
+        &[
+            "-t",
+            "tmpfs",
+            "-o",
+            "mode=1777,size=256m",
+            "tmpfs",
+            "/dev/shm",
+        ],
+    );
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+    );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
-    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700))
+    {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
@@ -31,9 +45,12 @@ fn main() {
             _ => {}
         }
     }
-    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    println!();
+    println!("Alpenglow boot (rust-init)");
+    println!();
     let err = Command::new("/usr/sbin/dinit")
         .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
+        .env_clear()
         .exec();
     eprintln!("init: dinit exec failed: {}", err);
     let _ = Command::new("/usr/bin/sh").env_clear().exec();


### PR DESCRIPTION
🎯 **What:** Modified the initramfs `init.rs` script to clear the environment before executing `/usr/sbin/dinit`.
⚠️ **Risk:** Without `.env_clear()`, critical system initialization processes (like `dinit` and potentially any child processes) would inherit the environment of the init process. This could allow an attacker or misconfiguration to pass sensitive or compromised environment variables down into the running system, potentially leading to privilege escalation or unauthorized behavior.
🛡️ **Solution:** Appended `.env_clear()` to `Command::new("/usr/sbin/dinit")` in `system/backends/appliance/initramfs/init.rs` to ensure a completely clean environment is provided when transitioning from the initramfs environment to the actual system init.

---
*PR created automatically by Jules for task [2762364298750337662](https://jules.google.com/task/2762364298750337662) started by @undivisible*