### PR TITLE
🧪 Add edge case tests for wU64 helper

### DIFF
--- a/system/kernelctl-zig/src/main.zig
+++ b/system/kernelctl-zig/src/main.zig
@@ -260,3 +260,35 @@ test "wU64 does not write on null" {
     };
     return error.ExpectedFileNotFound;
 }
+
+test "wU64 writes 0 correctly" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_zero.txt", 0);
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_zero.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("0\n", data);
+}
+
+test "wU64 writes max u64 correctly" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_max.txt", 18446744073709551615);
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_max.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("18446744073709551615\n", data);
+}


### PR DESCRIPTION
🎯 **What:** Add testing for boundary conditions (0 and max u64) to wU64 helper.
📊 **Coverage:** The `wU64` function now tests `0` and `18446744073709551615` in addition to normal paths and nulls.
✨ **Result:** Increased test coverage and confidence in `wU64` buffer allocation safety.

---
*PR created automatically by Jules for task [10892674302538361812](https://jules.google.com/task/10892674302538361812) started by @undivisible*