### PR TITLE
🧹 Refactor run_upgrade into smaller functions

### DIFF
--- a/system/oil/src/install.rs
+++ b/system/oil/src/install.rs
@@ -234,11 +234,15 @@ mod tests {
         let loaded = state.load().expect("Failed to load");
         assert_eq!(loaded.len(), 2);
 
-        let pkg_x = loaded.get("pkg-x").expect("pkg-x should exist in loaded map");
+        let pkg_x = loaded
+            .get("pkg-x")
+            .expect("pkg-x should exist in loaded map");
         assert_eq!(pkg_x.name, "pkg-x");
         assert_eq!(pkg_x.version, "1.0.0");
 
-        let pkg_y = loaded.get("pkg-y").expect("pkg-y should exist in loaded map");
+        let pkg_y = loaded
+            .get("pkg-y")
+            .expect("pkg-y should exist in loaded map");
         assert_eq!(pkg_y.name, "pkg-y");
         assert_eq!(pkg_y.version, "2.0.0");
 

--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -200,7 +200,11 @@ fn load_registry() -> Result<PackageIndex> {
         let registry = tap::TapRegistry::new(&tap.name, &tap.url);
         match registry.load() {
             Ok(index) => {
-                eprintln!("Loaded {} packages from tap {}", index.packages.len(), tap.name);
+                eprintln!(
+                    "Loaded {} packages from tap {}",
+                    index.packages.len(),
+                    tap.name
+                );
                 all.extend(index.packages);
             }
             Err(e) => eprintln!("warning: failed to load tap {}: {}", tap.name, e),
@@ -223,7 +227,11 @@ fn refresh_registry() -> Result<PackageIndex> {
         let registry = tap::TapRegistry::new(&tap.name, &tap.url);
         match registry.update() {
             Ok(index) => {
-                eprintln!("Refreshed {} packages from tap {}", index.packages.len(), tap.name);
+                eprintln!(
+                    "Refreshed {} packages from tap {}",
+                    index.packages.len(),
+                    tap.name
+                );
                 all.extend(index.packages);
             }
             Err(e) => eprintln!("warning: failed to refresh tap {}: {}", tap.name, e),
@@ -374,21 +382,15 @@ fn run_reinstall(packages: Vec<String>, all: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
-    let mut state = install::InstallState::new()?;
-    let installed = state.load()?;
-    if installed.is_empty() {
-        println!("No packages installed");
-        return Ok(());
-    }
-    let index = load_registry()?;
-    let targets: Vec<String> = if packages.is_empty() {
-        installed.keys().cloned().collect()
-    } else {
-        packages
-    };
+fn upgrade_packages(
+    targets: &[String],
+    installed: &std::collections::HashMap<String, install::InstalledPackage>,
+    index: &PackageIndex,
+    state: &mut install::InstallState,
+    dry_run: bool,
+) -> Result<usize> {
     let mut upgraded = 0;
-    for name in &targets {
+    for name in targets {
         if let Some(current) = installed.get(name) {
             if current.pinned {
                 continue;
@@ -405,15 +407,31 @@ fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
                         let dest = std::path::PathBuf::from("/usr/local");
                         install_package(latest, &dest)?;
                         state.mark_installed(name, Some(latest.version.as_str()));
-                        println!(
-                            "Upgraded {name}: {} → {}",
-                            current.version, latest.version
-                        );
+                        println!("Upgraded {name}: {} → {}", current.version, latest.version);
                     }
                 }
             }
         }
     }
+    Ok(upgraded)
+}
+
+fn run_upgrade(packages: Vec<String>, dry_run: bool) -> Result<()> {
+    let mut state = install::InstallState::new()?;
+    let installed = state.load()?;
+    if installed.is_empty() {
+        println!("No packages installed");
+        return Ok(());
+    }
+    let index = load_registry()?;
+    let targets: Vec<String> = if packages.is_empty() {
+        installed.keys().cloned().collect()
+    } else {
+        packages
+    };
+
+    let upgraded = upgrade_packages(&targets, &installed, &index, &mut state, dry_run)?;
+
     if upgraded == 0 {
         println!("All packages are up to date");
     }
@@ -474,7 +492,9 @@ fn run_tap(tap: Option<String>, action: Option<TapAction>) -> Result<()> {
                 for entry in taps.list() {
                     let registry = tap::TapRegistry::new(&entry.name, &entry.url);
                     match registry.update() {
-                        Ok(index) => println!("Updated {} ({} packages)", entry.name, index.packages.len()),
+                        Ok(index) => {
+                            println!("Updated {} ({} packages)", entry.name, index.packages.len())
+                        }
                         Err(e) => eprintln!("warning: failed to update tap {}: {}", entry.name, e),
                     }
                 }
@@ -586,23 +606,33 @@ mod tests {
             Ok(())
         }
         fn install(&self, packages: Vec<String>, dry_run: bool) -> Result<()> {
-            self.calls.borrow_mut().push(MockCall::Install(packages, dry_run));
+            self.calls
+                .borrow_mut()
+                .push(MockCall::Install(packages, dry_run));
             Ok(())
         }
         fn install_recipe(&self, recipe: PathBuf, dry_run: bool) -> Result<()> {
-            self.calls.borrow_mut().push(MockCall::InstallRecipe(recipe, dry_run));
+            self.calls
+                .borrow_mut()
+                .push(MockCall::InstallRecipe(recipe, dry_run));
             Ok(())
         }
         fn uninstall(&self, formulae: Vec<String>, all: bool) -> Result<()> {
-            self.calls.borrow_mut().push(MockCall::Uninstall(formulae, all));
+            self.calls
+                .borrow_mut()
+                .push(MockCall::Uninstall(formulae, all));
             Ok(())
         }
         fn reinstall(&self, packages: Vec<String>, all: bool) -> Result<()> {
-            self.calls.borrow_mut().push(MockCall::Reinstall(packages, all));
+            self.calls
+                .borrow_mut()
+                .push(MockCall::Reinstall(packages, all));
             Ok(())
         }
         fn upgrade(&self, packages: Vec<String>, dry_run: bool) -> Result<()> {
-            self.calls.borrow_mut().push(MockCall::Upgrade(packages, dry_run));
+            self.calls
+                .borrow_mut()
+                .push(MockCall::Upgrade(packages, dry_run));
             Ok(())
         }
         fn outdated(&self) -> Result<()> {
@@ -623,15 +653,22 @@ mod tests {
     #[test]
     fn test_execute_command_search() {
         let runner = MockRunner::new();
-        let cmd = Commands::Search { query: "foo".to_string() };
+        let cmd = Commands::Search {
+            query: "foo".to_string(),
+        };
         execute_command(cmd, &runner).expect("execute_command failed");
-        assert_eq!(runner.get_calls(), vec![MockCall::Search("foo".to_string())]);
+        assert_eq!(
+            runner.get_calls(),
+            vec![MockCall::Search("foo".to_string())]
+        );
     }
 
     #[test]
     fn test_execute_command_info() {
         let runner = MockRunner::new();
-        let cmd = Commands::Info { formula: "bar".to_string() };
+        let cmd = Commands::Info {
+            formula: "bar".to_string(),
+        };
         execute_command(cmd, &runner).expect("execute_command failed");
         assert_eq!(runner.get_calls(), vec![MockCall::Info("bar".to_string())]);
     }
@@ -646,7 +683,10 @@ mod tests {
         execute_command(cmd, &runner).expect("execute_command failed");
         assert_eq!(
             runner.get_calls(),
-            vec![MockCall::Install(vec!["pkg1".to_string(), "pkg2".to_string()], true)]
+            vec![MockCall::Install(
+                vec!["pkg1".to_string(), "pkg2".to_string()],
+                true
+            )]
         );
     }
 
@@ -660,7 +700,10 @@ mod tests {
         execute_command(cmd, &runner).expect("execute_command failed");
         assert_eq!(
             runner.get_calls(),
-            vec![MockCall::InstallRecipe(PathBuf::from("recipes/toybox.yml"), true)]
+            vec![MockCall::InstallRecipe(
+                PathBuf::from("recipes/toybox.yml"),
+                true
+            )]
         );
     }
 
@@ -758,11 +801,26 @@ mod tests {
     fn cli_parses_command_aliases() {
         let cases: Vec<(&[&str], MockCall)> = vec![
             (&["oil", "s", "vim"], MockCall::Search("vim".into())),
-            (&["oil", "i", "pkg"], MockCall::Install(vec!["pkg".into()], false)),
-            (&["oil", "add", "pkg"], MockCall::Install(vec!["pkg".into()], false)),
-            (&["oil", "rm", "pkg"], MockCall::Uninstall(vec!["pkg".into()], false)),
-            (&["oil", "del", "pkg"], MockCall::Uninstall(vec!["pkg".into()], false)),
-            (&["oil", "ri", "pkg"], MockCall::Reinstall(vec!["pkg".into()], false)),
+            (
+                &["oil", "i", "pkg"],
+                MockCall::Install(vec!["pkg".into()], false),
+            ),
+            (
+                &["oil", "add", "pkg"],
+                MockCall::Install(vec!["pkg".into()], false),
+            ),
+            (
+                &["oil", "rm", "pkg"],
+                MockCall::Uninstall(vec!["pkg".into()], false),
+            ),
+            (
+                &["oil", "del", "pkg"],
+                MockCall::Uninstall(vec!["pkg".into()], false),
+            ),
+            (
+                &["oil", "ri", "pkg"],
+                MockCall::Reinstall(vec!["pkg".into()], false),
+            ),
             (&["oil", "up"], MockCall::Upgrade(vec![], false)),
             (&["oil", "u"], MockCall::Update),
             (&["oil", "od"], MockCall::Outdated),

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -168,7 +168,10 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             continue;
         }
 
-        let stripped = entry_str.strip_prefix("./").unwrap_or(entry_str.as_ref()).trim_start_matches('/');
+        let stripped = entry_str
+            .strip_prefix("./")
+            .unwrap_or(entry_str.as_ref())
+            .trim_start_matches('/');
         if stripped.is_empty() || stripped.contains("..") {
             continue;
         }
@@ -222,7 +225,10 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             let mut entry = entry_?;
             let entry_path = entry.path()?;
             let path = entry_path.to_string_lossy();
-            let stripped = path.strip_prefix("./").unwrap_or(path.as_ref()).trim_start_matches('/');
+            let stripped = path
+                .strip_prefix("./")
+                .unwrap_or(path.as_ref())
+                .trim_start_matches('/');
             if stripped.is_empty() || stripped.contains("..") {
                 continue;
             }
@@ -287,17 +293,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_too_many_requested() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_too_many_requested(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream = create_gz_stream(b"data")?;
         let result = split_gzip_streams(&stream, 4);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("Requested 4 streams, maximum is 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("Requested 4 streams, maximum is 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_not_enough_streams() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_not_enough_streams(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream1 = create_gz_stream(b"data 1")?;
         let stream2 = create_gz_stream(b"data 2")?;
         let mut combined = Vec::new();
@@ -307,12 +319,17 @@ mod tests {
         let result = split_gzip_streams(&combined, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 2 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 2 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_corrupted_gzip() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_corrupted_gzip(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1 data")?;
         data.extend(create_gz_stream(b"stream 2 data")?);
         let mut corrupted_stream = create_gz_stream(b"stream 3 data")?;
@@ -334,24 +351,35 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_signature_info_success() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_success() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"dummy signature data";
         header.set_size(data.len() as u64);
         header.set_cksum();
-        tar_builder.append_data(&mut header, ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub", &data[..])?;
+        tar_builder.append_data(
+            &mut header,
+            ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub",
+            &data[..],
+        )?;
         let tar_data = tar_builder.into_inner()?;
         let result = extract_signature_info(&tar_data);
         assert!(result.is_some());
-        let (keyname, sig) = result.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Missing signature"))?;
-        assert_eq!(keyname, "alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub");
+        let (keyname, sig) = result.ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "Missing signature")
+        })?;
+        assert_eq!(
+            keyname,
+            "alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub"
+        );
         assert_eq!(sig, data);
         Ok(())
     }
 
     #[test]
-    fn test_extract_signature_info_not_found() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_not_found() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"some other file";
@@ -365,7 +393,8 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_signature_info_invalid_tar() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_invalid_tar(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let invalid_tar_data = b"not a tar file";
         let result = extract_signature_info(invalid_tar_data);
         assert!(result.is_none());

--- a/system/oil/src/tap.rs
+++ b/system/oil/src/tap.rs
@@ -123,9 +123,9 @@ impl TapRegistry {
         let cache_path = self.cache_path()?;
         let url = self.index_url();
         eprintln!("Fetching tap index: {url}");
-        let resp = ureq::get(&url).call().map_err(|e| {
-            OilError::Install(format!("Failed to fetch tap index from {url}: {e}"))
-        })?;
+        let resp = ureq::get(&url)
+            .call()
+            .map_err(|e| OilError::Install(format!("Failed to fetch tap index from {url}: {e}")))?;
         let mut body = Vec::new();
         resp.into_body()
             .into_reader()


### PR DESCRIPTION
🎯 **What:** The core package upgrading loop within `run_upgrade` in `system/oil/src/main.rs` was extracted into a separate helper function called `upgrade_packages`.
💡 **Why:** This refactoring improves maintainability and readability by reducing the size of the `run_upgrade` function (which was around 30 lines) and separating the core business logic of iterating and upgrading packages from the CLI output and state saving logic.
✅ **Verification:** I confirmed the change is safe by successfully running `cargo check`, `cargo fmt`, and `cargo test` on the `system/oil` directory. The automated code review also approved the changes.
✨ **Result:** The `run_upgrade` function is now cleaner and easier to follow, with its core logic properly encapsulated.

---
*PR created automatically by Jules for task [9958469890282670030](https://jules.google.com/task/9958469890282670030) started by @undivisible*