### PR TITLE
🧪 [testing improvement] Add missing edge cases tests for wU64

### DIFF
--- a/system/kernelctl-zig/src/main.zig
+++ b/system/kernelctl-zig/src/main.zig
@@ -260,3 +260,35 @@ test "wU64 does not write on null" {
     };
     return error.ExpectedFileNotFound;
 }
+
+test "wU64 writes 0" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_0.txt", 0);
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_0.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("0\n", data);
+}
+
+test "wU64 writes max u64" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    try wU64(tmp_path, "test_max.txt", std.math.maxInt(u64));
+
+    const data = try tmp.dir.readFileAlloc(testing.allocator, "test_max.txt", 1024);
+    defer testing.allocator.free(data);
+
+    try testing.expectEqualStrings("18446744073709551615\n", data);
+}


### PR DESCRIPTION
- 🎯 **What:** The testing gap addressed: Missing tests for edge values in `wU64` (e.g., zero and max possible value).
- 📊 **Coverage:** What scenarios are now tested: A test case with `std.math.maxInt(u64)` ensures the 32-byte formatting buffer won't overflow. A test case for `0` ensures correct stringification of zero.
- ✨ **Result:** The improvement in test coverage: Improved coverage and confidence in `wU64` handling boundaries.

---
*PR created automatically by Jules for task [15211842442643356582](https://jules.google.com/task/15211842442643356582) started by @undivisible*