### PR TITLE
🧪 Add tests for getErrno in zig-common.zig

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -88,6 +88,25 @@ pub fn getErrno(rc: usize) linux.E {
     return .SUCCESS;
 }
 
+test "getErrno" {
+    const testing = std.testing;
+
+    // Positive values (success)
+    try testing.expectEqual(.SUCCESS, getErrno(0));
+    try testing.expectEqual(.SUCCESS, getErrno(1));
+    try testing.expectEqual(.SUCCESS, getErrno(4096));
+
+    // Valid error ranges
+    try testing.expectEqual(.PERM, getErrno(@bitCast(@as(isize, -1))));
+    try testing.expectEqual(.NOENT, getErrno(@bitCast(@as(isize, -2))));
+    try testing.expectEqual(.BADF, getErrno(@bitCast(@as(isize, -9))));
+
+    // Edge cases
+    try testing.expectEqual(@as(linux.E, @enumFromInt(4095)), getErrno(@bitCast(@as(isize, -4095))));
+    try testing.expectEqual(.SUCCESS, getErrno(@bitCast(@as(isize, -4096))));
+    try testing.expectEqual(.SUCCESS, getErrno(@bitCast(@as(isize, -4097))));
+}
+
 pub fn checkSyscall(rc: usize) SyscallError!void {
     switch (getErrno(rc)) {
         .SUCCESS => return,


### PR DESCRIPTION
🎯 **What:** Added comprehensive test coverage for the `getErrno` function in `system/zig-common.zig`, a simple pure function mapping a return code to a standard error value.
📊 **Coverage:** The tests cover positive non-error return values, standard negative `linux.E` error mappings (like -1/PERM and -2/NOENT), and edge cases at the error boundary (-4095, -4096, -4097).
✨ **Result:** Improved test coverage and reliability by verifying correct mapping behavior and edge case handling of syscall return values.

---
*PR created automatically by Jules for task [7675663595365170669](https://jules.google.com/task/7675663595365170669) started by @undivisible*