### PR TITLE
🧪 [zig-common] Add test for makeDir

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -220,3 +220,34 @@ pub fn writeFile(path: []const u8, data: []const u8, truncate: bool) !void {
 pub fn writeStderr(msg: []const u8) void {
     _ = linux.write(2, msg.ptr, msg.len);
 }
+
+test "makeDir basic functionality and errors" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const tmp_path = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(tmp_path);
+
+    const test_dir = try std.fmt.allocPrint(testing.allocator, "{s}/test_mkdir", .{tmp_path});
+    defer testing.allocator.free(test_dir);
+
+    // Should create a new directory successfully
+    try makeDir(test_dir);
+    try testing.expect(fileExists(test_dir));
+
+    // Should not return an error if it already exists
+    try makeDir(test_dir);
+    try testing.expect(fileExists(test_dir));
+
+    // Error: Non-existent parent directory
+    const missing_parent_dir = try std.fmt.allocPrint(testing.allocator, "{s}/nonexistent/test_mkdir", .{tmp_path});
+    defer testing.allocator.free(missing_parent_dir);
+    try testing.expectError(error.FileNotFound, makeDir(missing_parent_dir));
+
+    // Error: NameTooLong
+    const long_path = try testing.allocator.alloc(u8, 4096);
+    defer testing.allocator.free(long_path);
+    @memset(long_path, 'a');
+    try testing.expectError(error.NameTooLong, makeDir(long_path));
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `makeDir` function in `system/zig-common.zig` to improve test coverage.
📊 **Coverage:** The new test covers successful directory creation (happy path), idempotency (no error if it already exists), missing parent directory error, and name too long error.
✨ **Result:** Increased test coverage and confidence in the `makeDir` utility function.

---
*PR created automatically by Jules for task [13521037161426351722](https://jules.google.com/task/13521037161426351722) started by @undivisible*