### PR TITLE
🔒 fix(security): ensure clean environment for all executed binaries in initramfs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -21,7 +21,7 @@ fn main() {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
-        match Command::new("modprobe").arg(m).status() {
+        match Command::new("modprobe").arg(m).env_clear().status() {
             Ok(status) if !status.success() => {
                 eprintln!("init: modprobe {} failed with status: {}", m, status);
             }
@@ -40,7 +40,7 @@ fn main() {
     let _ = Command::new("/usr/bin/sh").env_clear().exec();
 }
 fn run(prog: &str, args: &[&str]) {
-    if let Err(e) = Command::new(prog).args(args).status() {
+    if let Err(e) = Command::new(prog).args(args).env_clear().status() {
         eprintln!("init: {} failed: {}", prog, e);
     }
 }


### PR DESCRIPTION
🎯 **What:** Added `.env_clear()` to the `modprobe` execution and the `run` helper function in the initramfs `init.rs` script.
⚠️ **Risk:** If the initramfs environment variables are somehow manipulated, executing `modprobe` or system binaries (like `mount`) without clearing the environment could lead to privilege escalation or unintended execution behavior.
🛡️ **Solution:** Appended `.env_clear()` to the `std::process::Command::new()` chains for `modprobe` and the `run` helper function, ensuring they execute in a clean environment, consistent with the existing `dinit` and `/usr/bin/sh` executions.

---
*PR created automatically by Jules for task [6223569090776431809](https://jules.google.com/task/6223569090776431809) started by @undivisible*