### PR TITLE
🧪 Add edge case tests for checkSyscall

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -249,3 +249,27 @@ test "pathToZ" {
     const large_z = pathToZ(large_path, &buf);
     try testing.expect(large_z == null);
 }
+
+test "checkSyscall success" {
+    // 0 is SUCCESS
+    try checkSyscall(0);
+
+    // Positive values (like a valid fd or bytes read) are SUCCESS
+    try checkSyscall(100);
+}
+
+test "checkSyscall errors" {
+    const testing = std.testing;
+
+    // Test specific error mapping (e.g. ENOENT)
+    const enoent_rc: usize = @bitCast(-@as(isize, @intFromEnum(std.os.linux.E.NOENT)));
+    try testing.expectError(error.FileNotFound, checkSyscall(enoent_rc));
+
+    // Test another mapped error (e.g. EACCES)
+    const eacces_rc: usize = @bitCast(-@as(isize, @intFromEnum(std.os.linux.E.ACCES)));
+    try testing.expectError(error.AccessDenied, checkSyscall(eacces_rc));
+
+    // Test fallback for unmapped errors (e.g. EPERM)
+    const eperm_rc: usize = @bitCast(-@as(isize, @intFromEnum(std.os.linux.E.PERM)));
+    try testing.expectError(error.Unexpected, checkSyscall(eperm_rc));
+}


### PR DESCRIPTION
🎯 **What:** The missing edge case tests for `checkSyscall` in `zig-common` have been addressed by adding a test block for both success conditions and explicit error mapping.
📊 **Coverage:** Success mapping (return `void`) is now tested for `0` and positive values (e.g. 100). Error mapping is now tested for specific expected errors (e.g., `-ENOENT`, `-EACCES`) and the fallback `error.Unexpected` for unmapped values (e.g., `-EPERM`).
✨ **Result:** Test coverage for `checkSyscall` edge cases is explicitly implemented and verified, improving the safety net for `zig-common`'s syscall error conversion logic.

---
*PR created automatically by Jules for task [9298577984443515936](https://jules.google.com/task/9298577984443515936) started by @undivisible*