### PR TITLE
🧪 [testing] add error path test for untar

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -369,4 +369,13 @@ mod tests {
         assert!(result.is_none());
         Ok(())
     }
+
+    #[test]
+    fn test_untar_invalid_tar() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let invalid_tar_data = b"not a valid tar file";
+        let result = untar(invalid_tar_data, dir.path());
+        assert!(result.is_err());
+        Ok(())
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing error path test for untar
📊 **Coverage:** Untar's error paths when processing invalid short/random byte slices instead of a valid tar
✨ **Result:** Improved test coverage by ensuring invalid tar archives cleanly trigger an error instead of crashing or panicking

---
*PR created automatically by Jules for task [9201763208096661976](https://jules.google.com/task/9201763208096661976) started by @undivisible*