### PR TITLE
🧪 [testing] Add tests for parse_install_args

### DIFF
--- a/system/installer/src/lib.rs
+++ b/system/installer/src/lib.rs
@@ -183,3 +183,40 @@ fn is_block_device(metadata: &fs::Metadata) -> bool {
 fn is_block_device(_metadata: &fs::Metadata) -> bool {
     false
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_install_args_zero_args() {
+        let args: Vec<&str> = vec![];
+        let (source, target) = parse_install_args(args);
+        assert_eq!(source, default_live_source());
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_install_args_one_arg() {
+        let args = vec!["custom_source.img"];
+        let (source, target) = parse_install_args(args);
+        assert_eq!(source, PathBuf::from("custom_source.img"));
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_install_args_two_args() {
+        let args = vec!["custom_source.img", "/dev/nvme0n1"];
+        let (source, target) = parse_install_args(args);
+        assert_eq!(source, PathBuf::from("custom_source.img"));
+        assert_eq!(target, Some(PathBuf::from("/dev/nvme0n1")));
+    }
+
+    #[test]
+    fn test_parse_install_args_three_args() {
+        let args = vec!["custom_source.img", "/dev/nvme0n1", "extra_arg"];
+        let (source, target) = parse_install_args(args);
+        assert_eq!(source, PathBuf::from("custom_source.img"));
+        assert_eq!(target, Some(PathBuf::from("/dev/nvme0n1")));
+    }
+}


### PR DESCRIPTION
🎯 **What:** Tested the previously untested `parse_install_args` function.
📊 **Coverage:** Tests verify behavior for 0, 1, 2, and 3+ arguments.
✨ **Result:** Increased test coverage for installer CLI argument parsing logic.

---
*PR created automatically by Jules for task [7841705406030922003](https://jules.google.com/task/7841705406030922003) started by @undivisible*