### PR TITLE
🧪 Add error path test for missing gzip magic bytes in apk extractor

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -322,6 +322,16 @@ mod tests {
     }
 
     #[test]
+    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let data = b"dummy string without gzip magic bytes";
+        let result = split_gzip_streams(data, 3);
+        assert!(result.is_err());
+        let err_msg = result.expect_err("Expected an error").to_string();
+        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        Ok(())
+    }
+
+    #[test]
     fn test_extract_tracked_missing_file() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let dir = tempdir()?;
         let missing_path = dir.path().join("does_not_exist.apk");


### PR DESCRIPTION
🎯 **What:** Added missing error path test `test_split_gzip_streams_no_magic_bytes` in `system/oil/src/system/extractor/apk.rs` for `split_gzip_streams`.
📊 **Coverage:** Covered the scenario where no gzip magic bytes are found in the byte array.
✨ **Result:** Improved test coverage and reliability for `split_gzip_streams` error handling.

---
*PR created automatically by Jules for task [7147182757320089443](https://jules.google.com/task/7147182757320089443) started by @undivisible*