### PR TITLE
🧪 Add tests for install_image_maybe_compressed

### DIFF
--- a/system/installer/tests/install.rs
+++ b/system/installer/tests/install.rs
@@ -36,6 +36,38 @@ fn plain_auto_install_copies_image_when_allowed() {
 }
 
 #[test]
+fn zst_auto_install_decompresses_image_when_allowed() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("source.img.zst");
+    let target = dir.path().join("target.img");
+
+    // Valid zstd compressed payload for "alpenglow-compressed-test"
+    let zst_data: &[u8] = &[
+        0x28, 0xb5, 0x2f, 0xfd, 0x04, 0x58, 0xc9, 0x00, 0x00, 0x61, 0x6c, 0x70,
+        0x65, 0x6e, 0x67, 0x6c, 0x6f, 0x77, 0x2d, 0x63, 0x6f, 0x6d, 0x70, 0x72,
+        0x65, 0x73, 0x73, 0x65, 0x64, 0x2d, 0x74, 0x65, 0x73, 0x74, 0xc6, 0x62,
+        0xe6, 0x26
+    ];
+    fs::write(&source, zst_data).unwrap();
+
+    install_image_maybe_compressed(&source, &target, true).unwrap();
+    assert_eq!(fs::read(&target).unwrap(), b"alpenglow-compressed-test");
+}
+
+#[test]
+fn zst_auto_install_fails_on_invalid_zst() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("source.img.zst");
+    let target = dir.path().join("target.img");
+
+    // Invalid zstd payload
+    fs::write(&source, b"not-a-zst-file").unwrap();
+
+    let err = install_image_maybe_compressed(&source, &target, true).unwrap_err();
+    assert!(err.to_string().contains("zstd failed"));
+}
+
+#[test]
 fn install_args_default_to_live_source() {
     let (source, target) = parse_install_args(Vec::<&str>::new());
     assert_eq!(source, default_live_source());


### PR DESCRIPTION
🎯 **What:** Added missing tests for `install_image_maybe_compressed`. 📊 **Coverage:** Covered zstd decompression success and failure scenarios for the installer. ✨ **Result:** Improved test coverage for the installer library.

---
*PR created automatically by Jules for task [17107924477230638822](https://jules.google.com/task/17107924477230638822) started by @undivisible*