### PR TITLE
🧪 Add edge case tests for PackageIndex::find

### DIFF
--- a/system/oil/src/system/registry/mod.rs
+++ b/system/oil/src/system/registry/mod.rs
@@ -118,4 +118,42 @@ mod tests {
         assert!(index.find("libssl").is_some());
         assert!(index.find("nonexistent").is_none());
     }
+
+    #[test]
+    fn test_package_index_find_edge_cases() {
+        let empty_index = PackageIndex::new(vec![]);
+        assert!(empty_index.find("anything").is_none());
+        assert!(empty_index.find("").is_none());
+
+        let index = PackageIndex::new(vec![
+            PackageMetadata {
+                name: "pkgA".to_string(),
+                version: "1.0.0".to_string(),
+                description: String::new(),
+                download_url: String::new(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec!["providerA".to_string(), "shared".to_string()],
+            },
+            PackageMetadata {
+                name: "providerA".to_string(),
+                version: "2.0.0".to_string(),
+                description: String::new(),
+                download_url: String::new(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec!["shared".to_string()],
+            },
+        ]);
+
+        assert!(index.find("pkga").is_none());
+
+        let found = index.find("providerA").unwrap();
+        assert_eq!(found.version, "2.0.0");
+
+        let found_shared = index.find("shared").unwrap();
+        assert_eq!(found_shared.version, "1.0.0");
+    }
 }


### PR DESCRIPTION
🎯 **What:** Add missing edge case testing coverage for `PackageIndex::find`.
📊 **Coverage:** Now tests querying an empty index, empty string queries, case sensitivity, precedence (exact name overriding provides), and multiple providers resolution order.
✨ **Result:** Improved test coverage and reliability for package lookups in the registry index.

---
*PR created automatically by Jules for task [15051809022674510341](https://jules.google.com/task/15051809022674510341) started by @undivisible*