### PR TITLE
🧹 fix: replace insecure mktemp with secure temp dir in benchmark scripts

### DIFF
--- a/scripts/bench-boot-aarch64.sh
+++ b/scripts/bench-boot-aarch64.sh
@@ -22,8 +22,9 @@ fail() { echo "bench: $1" >&2; exit 1; }
 
 echo "==> Booting Alpenglow aarch64 in QEMU (${SMP} vCPU, ${MEMORY_MB}MB, ${ACCEL}) and timing boot..."
 
-OUTFILE="$(mktemp -t alpenglow-aarch64-bench-serial.XXXXXX)"
-rm -f "${OUTFILE}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT INT TERM
+OUTFILE="${TMP_DIR}/serial.log"
 
 START="$(date +%s%N)"
 

--- a/scripts/bench-boot.sh
+++ b/scripts/bench-boot.sh
@@ -26,8 +26,9 @@ fail() { echo "bench: $1" >&2; exit 1; }
 
 echo "==> Booting Alpenglow in QEMU (${SMP} vCPU, ${MEMORY_MB}MB, ${ACCEL}) and timing boot phases..."
 
-OUTFILE="$(mktemp -t alpenglow-bench-serial.XXXXXX)"
-rm -f "${OUTFILE}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT INT TERM
+OUTFILE="${TMP_DIR}/serial.log"
 
 START="$(date +%s%N)"
 


### PR DESCRIPTION
🎯 **What:** Replaced `mktemp -t ...XXXXXX` file creation and subsequent `rm -f` with `mktemp -d` and an `EXIT` trap in `bench-boot.sh` and `bench-boot-aarch64.sh`.
💡 **Why:** Fixes a code health issue where the `XXXXXX` template is falsely flagged as an `XXX` comment. More importantly, this refactoring eliminates a Time-Of-Check-to-Time-Of-Use (TOCTOU) vulnerability where the temporary file is created, deleted, and then recreated by a shell redirect, and also introduces proper cleanup to avoid polluting `/tmp`.
✅ **Verification:** Ran `bash -n` to verify syntax and confirmed safe temp directory creation.
✨ **Result:** Improved security, cleaner temp file handling, and resolved the code health linter warning.

---
*PR created automatically by Jules for task [1775336852579372559](https://jules.google.com/task/1775336852579372559) started by @undivisible*