### PR TITLE
🧹 [code health] Remove unwrap() in installer GUI

### DIFF
--- a/system/installer/src/bin/alpenglow-install-gui.rs
+++ b/system/installer/src/bin/alpenglow-install-gui.rs
@@ -323,9 +323,11 @@ fn main() {
             ))),
             Some(size(gpui::px(940.), gpui::px(620.))),
         );
-        cx.open_window(options, |_, cx| {
+        if let Err(e) = cx.open_window(options, |_, cx| {
             cx.new(|_| InstallerView::new(source, target))
-        })
-        .unwrap();
+        }) {
+            eprintln!("Failed to open window: {:?}", e);
+            cx.quit();
+        }
     });
 }


### PR DESCRIPTION
🎯 **What:** Removed an unsafe `.unwrap()` call in `alpenglow-install-gui.rs` when opening the main window.
💡 **Why:** Panicking via `.unwrap()` can crash the application abruptly. Gracefully handling the error by printing it and calling `cx.quit()` improves maintainability and readability, adhering to code health best practices.
✅ **Verification:** Verified via `cargo check` and `cargo test`.
✨ **Result:** The GUI application now handles window initialization errors safely without panicking.

---
*PR created automatically by Jules for task [4480980248593171170](https://jules.google.com/task/4480980248593171170) started by @undivisible*