### PR TITLE
🧪 Add table-driven tests for parse_dep_name

### DIFF
--- a/system/oil/src/system/registry/mod.rs
+++ b/system/oil/src/system/registry/mod.rs
@@ -64,29 +64,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_dep_name_simple() {
-        assert_eq!(parse_dep_name("libc6"), "libc6");
-    }
+    fn test_parse_dep_name() {
+        let cases = vec![
+            // happy path
+            ("libc6", "libc6"),
+            // with version
+            ("libc6 (>= 2.17)", "libc6"),
+            // with equals constraint
+            ("rg=14.1.1-r0", "rg"),
+            // complex edge cases
+            ("", ""),
+            ("   ", ""),
+            (">=1.0.0", ""),
+            ("pkg=1.0=2.0", "pkg"),
+            ("so:libssl.so.3", "so:libssl.so.3"),
+            ("cmd:bash", "cmd:bash"),
+            ("  pkg  ", "pkg"),
+        ];
 
-    #[test]
-    fn test_parse_dep_name_with_version() {
-        assert_eq!(parse_dep_name("libc6 (>= 2.17)"), "libc6");
-    }
-
-    #[test]
-    fn test_parse_dep_name_with_equals_constraint() {
-        assert_eq!(parse_dep_name("rg=14.1.1-r0"), "rg");
-    }
-
-    #[test]
-    fn test_parse_dep_name_complex_edge_cases() {
-        assert_eq!(parse_dep_name(""), "");
-        assert_eq!(parse_dep_name("   "), "");
-        assert_eq!(parse_dep_name(">=1.0.0"), "");
-        assert_eq!(parse_dep_name("pkg=1.0=2.0"), "pkg");
-        assert_eq!(parse_dep_name("so:libssl.so.3"), "so:libssl.so.3");
-        assert_eq!(parse_dep_name("cmd:bash"), "cmd:bash");
-        assert_eq!(parse_dep_name("  pkg  "), "pkg");
+        for (input, expected) in cases {
+            assert_eq!(
+                parse_dep_name(input),
+                expected,
+                "failed on input: '{}'",
+                input
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Replaced scattered parse_dep_name tests with a cleaner, table-driven approach.
📊 **Coverage:** Tests happy path (simple names), version constraints (e.g. `(>= 2.17)`), equal constraints (`rg=14.1.1-r0`), and complex edge cases like empty strings, spaces, and apk prefixes (`so:`, `cmd:`).
✨ **Result:** Improved test readability and maintainability for parse_dep_name string manipulation.

---
*PR created automatically by Jules for task [7226268350367570665](https://jules.google.com/task/7226268350367570665) started by @undivisible*