### PR TITLE
🧹 Refactor busybox installation in build-v86-initramfs.sh

### DIFF
--- a/scripts/build-v86-initramfs.sh
+++ b/scripts/build-v86-initramfs.sh
@@ -61,9 +61,8 @@ fi
 
 cp "${BUSYBOX}" "${ROOTFS}/bin/busybox"
 chmod 755 "${ROOTFS}/bin/busybox"
-for applet in sh ash mount mkdir mknod chmod cat ls pwd echo uname free dmesg clear hostname sleep stty setsid cttyhack; do
-  ln -sf busybox "${ROOTFS}/bin/${applet}"
-done
+need_docker
+docker run --rm --platform linux/386 -v "${ROOTFS}:/rootfs" alpine:3.20 chroot /rootfs /bin/busybox --install -s /bin
 cp "${OIL}" "${ROOTFS}/bin/oil"
 chmod 755 "${ROOTFS}/bin/oil"
 ln -sf oil "${ROOTFS}/bin/wax"


### PR DESCRIPTION
* 🎯 **What:** Use `busybox --install -s` via docker chroot instead of manually symlinking applets in `scripts/build-v86-initramfs.sh`.
* 💡 **Why:** Reduces brittle manual tracking of applets and improves code maintainability.
* ✅ **Verification:** Passed bash syntax checks and docker installation test during full initramfs build.
* ✨ **Result:** A cleaner and more robust busybox installation process.

---
*PR created automatically by Jules for task [18271519474535607422](https://jules.google.com/task/18271519474535607422) started by @undivisible*