### PR TITLE
🧪 Add tests and refactor find_apk_key for APK extraction

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -13,13 +13,18 @@ use crate::system::verifier;
 
 /// Try well-known Alpine public key paths. Returns the first PEM found.
 fn find_apk_key(keyname: &str) -> Option<String> {
+    find_apk_key_in_root(Path::new("/"), keyname)
+}
+
+fn find_apk_key_in_root(root: &Path, keyname: &str) -> Option<String> {
     let candidates = [
-        format!("/etc/apk/keys/{keyname}.pub"),
-        format!("/usr/share/apk/keys/{keyname}.pub"),
-        format!("/etc/apk/keys/alpine-devel@lists.alpinelinux.org-{keyname}.pub"),
-        format!("/etc/apk/keys/alpine-devel@lists.alpinelinux.org-{keyname}.pem"),
+        format!("etc/apk/keys/{keyname}.pub"),
+        format!("usr/share/apk/keys/{keyname}.pub"),
+        format!("etc/apk/keys/alpine-devel@lists.alpinelinux.org-{keyname}.pub"),
+        format!("etc/apk/keys/alpine-devel@lists.alpinelinux.org-{keyname}.pem"),
     ];
-    for path in &candidates {
+    for candidate in &candidates {
+        let path = root.join(candidate);
         if let Ok(pem) = std::fs::read_to_string(path) {
             if pem.contains("BEGIN") {
                 return Some(pem);
@@ -168,7 +173,10 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             continue;
         }
 
-        let stripped = entry_str.strip_prefix("./").unwrap_or(entry_str.as_ref()).trim_start_matches('/');
+        let stripped = entry_str
+            .strip_prefix("./")
+            .unwrap_or(entry_str.as_ref())
+            .trim_start_matches('/');
         if stripped.is_empty() || stripped.contains("..") {
             continue;
         }
@@ -221,7 +229,10 @@ fn untar(tar_data: &[u8], dest_dir: &Path) -> Result<(Vec<PathBuf>, Vec<PathBuf>
             let mut entry = entry_?;
             let entry_path = entry.path()?;
             let path = entry_path.to_string_lossy();
-            let stripped = path.strip_prefix("./").unwrap_or(path.as_ref()).trim_start_matches('/');
+            let stripped = path
+                .strip_prefix("./")
+                .unwrap_or(path.as_ref())
+                .trim_start_matches('/');
             if stripped.is_empty() || stripped.contains("..") {
                 continue;
             }
@@ -272,17 +283,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_too_many_requested() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_too_many_requested(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream = create_gz_stream(b"data")?;
         let result = split_gzip_streams(&stream, 4);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("Requested 4 streams, maximum is 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("Requested 4 streams, maximum is 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_not_enough_streams() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_not_enough_streams(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream1 = create_gz_stream(b"data 1")?;
         let stream2 = create_gz_stream(b"data 2")?;
         let mut combined = Vec::new();
@@ -292,12 +309,17 @@ mod tests {
         let result = split_gzip_streams(&combined, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 2 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 2 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_corrupted_gzip() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_corrupted_gzip(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1 data")?;
         data.extend(create_gz_stream(b"stream 2 data")?);
         let mut corrupted_stream = create_gz_stream(b"stream 3 data")?;
@@ -329,24 +351,35 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_signature_info_success() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_success() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"dummy signature data";
         header.set_size(data.len() as u64);
         header.set_cksum();
-        tar_builder.append_data(&mut header, ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub", &data[..])?;
+        tar_builder.append_data(
+            &mut header,
+            ".SIGN.RSA.alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub",
+            &data[..],
+        )?;
         let tar_data = tar_builder.into_inner()?;
         let result = extract_signature_info(&tar_data);
         assert!(result.is_some());
-        let (keyname, sig) = result.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Missing signature"))?;
-        assert_eq!(keyname, "alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub");
+        let (keyname, sig) = result.ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::NotFound, "Missing signature")
+        })?;
+        assert_eq!(
+            keyname,
+            "alpine-devel@lists.alpinelinux.org-6165ee59.rsa.pub"
+        );
         assert_eq!(sig, data);
         Ok(())
     }
 
     #[test]
-    fn test_extract_signature_info_not_found() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_not_found() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
         let mut tar_builder = tar::Builder::new(Vec::new());
         let mut header = tar::Header::new_gnu();
         let data = b"some other file";
@@ -360,7 +393,8 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_signature_info_invalid_tar() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_extract_signature_info_invalid_tar(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let invalid_tar_data = b"not a tar file";
         let result = extract_signature_info(invalid_tar_data);
         assert!(result.is_none());
@@ -373,6 +407,62 @@ mod tests {
         let invalid_tar_data = b"not a valid tar file";
         let result = untar(invalid_tar_data, dir.path());
         assert!(result.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_apk_key_in_root_happy_path_etc(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let keys_dir = dir.path().join("etc/apk/keys");
+        std::fs::create_dir_all(&keys_dir)?;
+        let key_path = keys_dir.join("testkey.pub");
+        std::fs::write(
+            &key_path,
+            "some key data\n-----BEGIN PUBLIC KEY-----\nmore data",
+        )?;
+
+        let result = find_apk_key_in_root(dir.path(), "testkey");
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("BEGIN PUBLIC KEY"));
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_apk_key_in_root_happy_path_usr(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let keys_dir = dir.path().join("usr/share/apk/keys");
+        std::fs::create_dir_all(&keys_dir)?;
+        let key_path = keys_dir.join("testkey2.pub");
+        std::fs::write(&key_path, "-----BEGIN PUBLIC KEY-----\ndata")?;
+
+        let result = find_apk_key_in_root(dir.path(), "testkey2");
+        assert!(result.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_apk_key_in_root_invalid_content(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let keys_dir = dir.path().join("etc/apk/keys");
+        std::fs::create_dir_all(&keys_dir)?;
+        let key_path = keys_dir.join("testkey3.pub");
+        std::fs::write(&key_path, "just some random data, no begin block")?;
+
+        let result = find_apk_key_in_root(dir.path(), "testkey3");
+        assert!(result.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn test_find_apk_key_in_root_not_found() -> std::result::Result<(), Box<dyn std::error::Error>>
+    {
+        let dir = tempdir()?;
+        // Empty directory
+        let result = find_apk_key_in_root(dir.path(), "testkey4");
+        assert!(result.is_none());
         Ok(())
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was an untested find_apk_key function which uses hard-coded filesystem paths. Refactored find_apk_key into find_apk_key_in_root to allow dependency injection of the root path, making the logic testable with temporary directories.
📊 **Coverage:** Added tests covering successful key lookup in multiple standard directories, failure to lookup due to missing files, and failure to lookup due to invalid key content lacking the 'BEGIN' token.
✨ **Result:** Test coverage improved by verifying the core key discovery logic under various isolated filesystem conditions without polluting the host OS state.

---
*PR created automatically by Jules for task [15639098935324213749](https://jules.google.com/task/15639098935324213749) started by @undivisible*