### PR TITLE
🧪 Add tests for contains_ignore_ascii_case

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -552,6 +552,24 @@ mod tests {
     use crate::test_support::IsolatedHome;
 
     #[test]
+    fn test_contains_ignore_ascii_case() {
+        // Happy paths
+        assert!(contains_ignore_ascii_case("hello world", b"world"));
+        assert!(contains_ignore_ascii_case("HELLO WORLD", b"world"));
+        assert!(contains_ignore_ascii_case("hello world", b"WORLD"));
+        assert!(contains_ignore_ascii_case("HeLlO wOrLd", b"WoRlD"));
+
+        // Error/not found
+        assert!(!contains_ignore_ascii_case("hello world", b"earth"));
+        assert!(!contains_ignore_ascii_case("hello", b"hello world"));
+
+        // Edge cases
+        assert!(contains_ignore_ascii_case("hello", b"")); // empty needle
+        assert!(contains_ignore_ascii_case("", b"")); // empty both
+        assert!(!contains_ignore_ascii_case("", b"hello")); // empty haystack
+    }
+
+    #[test]
     fn test_run_install_recipe_dry_run_does_not_touch_network() {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().join("pkg.yml");


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for `contains_ignore_ascii_case` function in `system/oil/src/main.rs` to address a testing gap.
📊 **Coverage:** Covered happy paths (exact match, case-insensitive match, mixed case), edge cases (empty needle, empty haystack, empty both, haystack shorter than needle), and error/not found conditions.
✨ **Result:** Improved test coverage and reliability for string searching operations.

---
*PR created automatically by Jules for task [6223431706319764278](https://jules.google.com/task/6223431706319764278) started by @undivisible*