### PR TITLE
🔒 Fix Missing Integrity Check for Downloaded Asset in boot-native.sh

### DIFF
--- a/scripts/boot-native.sh
+++ b/scripts/boot-native.sh
@@ -347,6 +347,7 @@ if [ "${BUILD_SERVICES}" = "1" ]; then
     CHRONY_VERSION="4.5"
     cd /tmp
     curl -fsSL "https://chrony-project.org/releases/chrony-${CHRONY_VERSION}.tar.gz" -o chrony.tar.gz 2>/dev/null || exit 0
+    echo "19fe1d9f4664d445a69a96c71e8fdb60bcd8df24c73d1386e02287f7366ad422  chrony.tar.gz" | sha256sum -c - || exit 1
     tar -xf chrony.tar.gz
     cd "chrony-${CHRONY_VERSION}"
     ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var \


### PR DESCRIPTION
🎯 **What:** Added a SHA256 integrity check for the downloaded chrony source tarball in `scripts/boot-native.sh`.
⚠️ **Risk:** Without an integrity check, a Man-in-the-Middle (MitM) attacker or compromised server could serve a malicious version of the chrony source code. Since the code is subsequently compiled and executed as part of the build process (which may run with elevated privileges or produce a compromised binary for the target system), this could lead to arbitrary code execution or a compromised system image.
🛡️ **Solution:** Added a strict `sha256sum -c` validation step immediately after downloading `chrony.tar.gz` and before extracting it, ensuring only the expected source code is processed.

---
*PR created automatically by Jules for task [6670466517801046605](https://jules.google.com/task/6670466517801046605) started by @undivisible*