### PR TITLE
🧹 [code health] fix mktemp TOCTOU and remove XXX placeholder

### DIFF
--- a/scripts/bench-boot-aarch64.sh
+++ b/scripts/bench-boot-aarch64.sh
@@ -22,8 +22,9 @@ fail() { echo "bench: $1" >&2; exit 1; }
 
 echo "==> Booting Alpenglow aarch64 in QEMU (${SMP} vCPU, ${MEMORY_MB}MB, ${ACCEL}) and timing boot..."
 
-OUTFILE="$(mktemp -t alpenglow-aarch64-bench-serial.XXXXXX)"
-rm -f "${OUTFILE}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+OUTFILE="${TMP_DIR}/serial.log"
 
 START="$(date +%s%N)"
 

--- a/scripts/bench-boot.sh
+++ b/scripts/bench-boot.sh
@@ -26,8 +26,9 @@ fail() { echo "bench: $1" >&2; exit 1; }
 
 echo "==> Booting Alpenglow in QEMU (${SMP} vCPU, ${MEMORY_MB}MB, ${ACCEL}) and timing boot phases..."
 
-OUTFILE="$(mktemp -t alpenglow-bench-serial.XXXXXX)"
-rm -f "${OUTFILE}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+OUTFILE="${TMP_DIR}/serial.log"
 
 START="$(date +%s%N)"
 


### PR DESCRIPTION
🎯 **What:** Replaced file-based `mktemp` with `mktemp -d` and added a cleanup trap in benchmark scripts.
💡 **Why:** Resolves a false-positive "XXX" comment flag from `mktemp` templates. Simultaneously fixes a TOCTOU vulnerability where the temporary file was deleted before use, and ensures proper cleanup of temporary files upon exit.
✅ **Verification:** Verified syntax with `sh -n`. Manual review confirms `mktemp -d` behavior and trap safety.
✨ **Result:** Improved maintainability, eliminated the false-positive warning, and hardened the scripts against temporary file vulnerabilities.

---
*PR created automatically by Jules for task [16904209099218440953](https://jules.google.com/task/16904209099218440953) started by @undivisible*