### PR TITLE
🧪 Add tests for cache_key utility

### DIFF
--- a/system/oil/src/util/cache.rs
+++ b/system/oil/src/util/cache.rs
@@ -12,3 +12,17 @@ pub fn is_cache_fresh(path: &std::path::Path) -> bool {
 pub fn cache_key(value: &str) -> String {
     value.chars().map(|c| if c.is_alphanumeric() { c } else { '-' }).collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_key() {
+        assert_eq!(cache_key("hello"), "hello");
+        assert_eq!(cache_key("Hello_World"), "Hello-World");
+        assert_eq!(cache_key("a1b2_c3!d4"), "a1b2-c3-d4");
+        assert_eq!(cache_key("!@#$%^&*()"), "----------");
+        assert_eq!(cache_key(""), "");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the `cache_key` function in `system/oil/src/util/cache.rs`.
📊 **Coverage:** Covered alphanumeric strings, special characters replaced by dashes, and empty strings.
✨ **Result:** Enhanced test coverage and prevented regressions on string transformations for cache keys.

---
*PR created automatically by Jules for task [1179573512708771647](https://jules.google.com/task/1179573512708771647) started by @undivisible*