### PR TITLE
🧪 Add tests for is_cache_fresh function

### DIFF
--- a/system/oil/src/util/cache.rs
+++ b/system/oil/src/util/cache.rs
@@ -10,12 +10,17 @@ pub fn is_cache_fresh(path: &std::path::Path) -> bool {
     false
 }
 pub fn cache_key(value: &str) -> String {
-    value.chars().map(|c| if c.is_alphanumeric() { c } else { '-' }).collect()
+    value
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '-' })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, SystemTime};
+    use tempfile::NamedTempFile;
 
     #[test]
     fn test_cache_key() {
@@ -24,5 +29,37 @@ mod tests {
         assert_eq!(cache_key("a1b2_c3!d4"), "a1b2-c3-d4");
         assert_eq!(cache_key("!@#$%^&*()"), "----------");
         assert_eq!(cache_key(""), "");
+    }
+
+    #[test]
+    fn test_is_cache_fresh_not_exists() {
+        let path = std::path::Path::new("/path/does/not/exist");
+        assert!(!is_cache_fresh(path));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_new_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        assert!(is_cache_fresh(tmp.path()));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_stale_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let old_time = SystemTime::now() - Duration::from_secs(25 * 3600);
+        tmp.as_file()
+            .set_times(std::fs::FileTimes::new().set_modified(old_time))
+            .unwrap();
+        assert!(!is_cache_fresh(tmp.path()));
+    }
+
+    #[test]
+    fn test_is_cache_fresh_future_file() {
+        let tmp = NamedTempFile::new().unwrap();
+        let future_time = SystemTime::now() + Duration::from_secs(3600);
+        tmp.as_file()
+            .set_times(std::fs::FileTimes::new().set_modified(future_time))
+            .unwrap();
+        assert!(!is_cache_fresh(tmp.path()));
     }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the public cache freshness function `is_cache_fresh` in `system/oil/src/util/cache.rs`.
📊 **Coverage:** What scenarios are now tested include non-existent files (false), newly created files (fresh, true), stale files over 24 hours old (false), and files with modification times in the future (false).
✨ **Result:** The improvement in test coverage ensures the cache freshness logic behaves predictably and safeguards against regressions.

---
*PR created automatically by Jules for task [1179573512708768708](https://jules.google.com/task/1179573512708768708) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes plus whitespace formatting; no production logic changes.
> 
> **Overview**
> Adds **unit tests** for `is_cache_fresh` in `system/oil/src/util/cache.rs` using `tempfile::NamedTempFile` and `FileTimes` to control modification times.
> 
> Coverage includes: missing paths (false), newly created files (true within 24h), files older than 25 hours (false), and files with future mtimes (false, via `duration_since` failure).
> 
> The only non-test change is **cosmetic reformatting** of `cache_key`; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58fb75a848470fecb0dbf66ea8c6436c8f04d65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->