### PR TITLE
🧪 Add test coverage for parse_installer_args

### DIFF
--- a/system/installer/src/lib.rs
+++ b/system/installer/src/lib.rs
@@ -267,4 +267,66 @@ mod tests {
             _ => panic!("Expected Io error"),
         }
     }
+
+    #[test]
+    fn test_parse_installer_args_empty() {
+        let args: Vec<OsString> = vec![];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, false);
+        assert_eq!(source, default_live_source());
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_installer_args_tui_only() {
+        let args: Vec<OsString> = vec![OsString::from("--tui")];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, true);
+        assert_eq!(source, default_live_source());
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_installer_args_source_only() {
+        let args: Vec<OsString> = vec![OsString::from("source.img")];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, false);
+        assert_eq!(source, PathBuf::from("source.img"));
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_installer_args_tui_and_source() {
+        let args: Vec<OsString> = vec![OsString::from("--tui"), OsString::from("source.img")];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, true);
+        assert_eq!(source, PathBuf::from("source.img"));
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_parse_installer_args_tui_source_target() {
+        let args: Vec<OsString> = vec![
+            OsString::from("--tui"),
+            OsString::from("source.img"),
+            OsString::from("/dev/sda"),
+        ];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, true);
+        assert_eq!(source, PathBuf::from("source.img"));
+        assert_eq!(target, Some(PathBuf::from("/dev/sda")));
+    }
+
+    #[test]
+    fn test_parse_installer_args_source_tui_target() {
+        let args: Vec<OsString> = vec![
+            OsString::from("source.img"),
+            OsString::from("--tui"),
+            OsString::from("/dev/sda"),
+        ];
+        let (tui, source, target) = parse_installer_args(args);
+        assert_eq!(tui, true);
+        assert_eq!(source, PathBuf::from("source.img"));
+        assert_eq!(target, Some(PathBuf::from("/dev/sda")));
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for the `parse_installer_args` function in `system/installer/src/lib.rs`, which parses command-line arguments (handling the optional `--tui` flag alongside source and target positional arguments).
📊 **Coverage:** The new tests cover empty arguments, `--tui` only, source only, `--tui` with source, `--tui` with source and target, and out-of-order `--tui` flag relative to positionals.
✨ **Result:** Enhanced test coverage and reliability for the installer argument parsing logic.

---
*PR created automatically by Jules for task [917440784942043618](https://jules.google.com/task/917440784942043618) started by @undivisible*