### PR TITLE
fix(release): preserve initramfs codec identity

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -4,10 +4,11 @@
 set -eu
 
 ROOT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+. "${ROOT_DIR}/scripts/lib/initramfs-codec-identity.sh"
 OUT_DIR="${ROOT_DIR}/build/release"
 IMAGE="${OUT_DIR}/alpenglow.img"
 KERNEL="${OUT_DIR}/vmlinuz"
-INITRAMFS="${OUT_DIR}/initramfs.cpio.gz"
+INITRAMFS=""
 LIMINE_DIR="${OUT_DIR}/limine"
 MNT_ROOT="${OUT_DIR}/mnt/root"
 MNT_STATE="${OUT_DIR}/mnt/state"
@@ -44,14 +45,14 @@ KERNEL_BUILD=1 BUILD_ONLY=1 "${ROOT_DIR}/scripts/boot-native.sh" 2>&1 | tail -5 
 }
 cp "${KERNEL}" "${OUT_DIR}/vmlinuz" 2>/dev/null || true
 cp "${OUT_DIR}/../native/vmlinuz" "${KERNEL}" 2>/dev/null || true
-for native_initramfs in "${OUT_DIR}/../native/initramfs.cpio.zst" "${OUT_DIR}/../native/initramfs.cpio.lz4"; do
-  if [ -f "${native_initramfs}" ]; then
-    cp "${native_initramfs}" "${INITRAMFS}"
-    break
-  fi
-done
+INITRAMFS="$(initramfs_resolve_release_artifact "${OUT_DIR}/../native" "${OUT_DIR}" 2>/dev/null || true)"
+if [ -z "${INITRAMFS}" ] && [ -f "${OUT_DIR}/initramfs.cpio.gz" ]; then
+  INITRAMFS="${OUT_DIR}/initramfs.cpio.gz"
+fi
 test -f "${KERNEL}" || { echo "missing built kernel: ${KERNEL}" >&2; exit 1; }
-test -f "${INITRAMFS}" || { echo "missing built initramfs: ${INITRAMFS}" >&2; exit 1; }
+test -n "${INITRAMFS}" && test -f "${INITRAMFS}" || { echo "missing built initramfs under ${OUT_DIR}" >&2; exit 1; }
+initramfs_assert_codec_identity "${INITRAMFS}" || exit 1
+INITRAMFS_BASENAME="$(basename -- "${INITRAMFS}")"
 
 # ── 2. Fetch Limine bootloader ─────────────────────────────────────
 echo "→ Fetching Limine ${LIMINE_VERSION}..."
@@ -105,12 +106,12 @@ echo "→ Installing system..."
 sudo mount "${LOOP_ROOT}" "${MNT_ROOT}"
 sudo mkdir -p "${MNT_ROOT}/boot" "${MNT_ROOT}/state"
 sudo cp "${KERNEL}" "${MNT_ROOT}/boot/vmlinuz"
-sudo cp "${INITRAMFS}" "${MNT_ROOT}/boot/initramfs.cpio.gz"
+sudo cp "${INITRAMFS}" "${MNT_ROOT}/boot/${INITRAMFS_BASENAME}"
 
 # ── 6. Install Limine ─────────────────────────────────────────────
 echo "→ Installing Limine bootloader..."
 sudo mkdir -p "${MNT_ROOT}/boot/limine"
-cat > /tmp/limine.conf << 'LIMINE'
+cat > /tmp/limine.conf << LIMINE
 # Alpenglow Limine configuration
 timeout: 5
 verbose: no
@@ -119,7 +120,7 @@ verbose: no
   protocol: linux
   path: boot():/boot/vmlinuz
   cmdline: console=tty0 console=ttyS0 init=/init alpenglow.state=LABEL=alpenglow-state
-  module_path: boot():/boot/initramfs.cpio.gz
+  module_path: boot():/boot/${INITRAMFS_BASENAME}
 LIMINE
 sudo cp /tmp/limine.conf "${MNT_ROOT}/boot/limine/limine.conf"
 sudo "${LIMINE_DIR}/limine" bios-install "${IMAGE}" 2>/dev/null || true

--- a/scripts/ci-os-appliance.sh
+++ b/scripts/ci-os-appliance.sh
@@ -106,4 +106,10 @@ assert_contains "${tmp_root}/etc/alpenglow/world" '^alpenglowed$'
 assert_contains "${tmp_root}/etc/alpenglow/system.json" '"compositor":"alpenglowed"'
 scripts/ci-profile-matrix.sh
 
+assert_file scripts/lib/initramfs-codec-identity.sh
+assert_file scripts/test-initramfs-codec-identity.sh
+sh -n scripts/lib/initramfs-codec-identity.sh
+sh -n scripts/test-initramfs-codec-identity.sh
+sh scripts/test-initramfs-codec-identity.sh
+
 printf 'ci-os-appliance: ok\n'

--- a/scripts/lib/initramfs-codec-identity.sh
+++ b/scripts/lib/initramfs-codec-identity.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+initramfs_detect_codec() {
+  path="$1"
+  [ -f "${path}" ] || return 1
+  magic="$(od -An -tx1 -N4 "${path}" 2>/dev/null | tr -d ' \n')"
+  case "${magic}" in
+    1f8b*) printf '%s\n' gzip ;;
+    28b52ffd) printf '%s\n' zstd ;;
+    04224d18) printf '%s\n' lz4 ;;
+    *) printf '%s\n' unknown ;;
+  esac
+}
+
+initramfs_expected_basename() {
+  codec="$1"
+  case "${codec}" in
+    gzip) printf '%s\n' initramfs.cpio.gz ;;
+    zstd) printf '%s\n' initramfs.cpio.zst ;;
+    lz4) printf '%s\n' initramfs.cpio.lz4 ;;
+    *) return 1 ;;
+  esac
+}
+
+initramfs_assert_codec_identity() {
+  path="$1"
+  codec="$(initramfs_detect_codec "${path}")" || return 1
+  expected="$(initramfs_expected_basename "${codec}")" || {
+    printf 'initramfs-codec-identity: unknown codec for %s\n' "${path}" >&2
+    return 1
+  }
+  base="$(basename -- "${path}")"
+  [ "${base}" = "${expected}" ] || {
+    printf 'initramfs-codec-identity: %s is %s but named %s (want %s)\n' \
+      "${path}" "${codec}" "${base}" "${expected}" >&2
+    return 1
+  }
+}
+
+initramfs_resolve_release_artifact() {
+  native_dir="$1"
+  out_dir="$2"
+  for name in initramfs.cpio.zst initramfs.cpio.lz4 initramfs.cpio.gz; do
+    src="${native_dir}/${name}"
+    if [ -f "${src}" ]; then
+      dest="${out_dir}/${name}"
+      cp "${src}" "${dest}"
+      initramfs_assert_codec_identity "${dest}" || return 1
+      printf '%s\n' "${dest}"
+      return 0
+    fi
+  done
+  return 1
+}

--- a/scripts/test-initramfs-codec-identity.sh
+++ b/scripts/test-initramfs-codec-identity.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -eu
+
+REPO_ROOT="$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
+cd "${REPO_ROOT}"
+fail() { printf 'test-initramfs-codec-identity: %s\n' "$1" >&2; exit 1; }
+
+. "${REPO_ROOT}/scripts/lib/initramfs-codec-identity.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "${tmp}"' EXIT INT TERM
+native="${tmp}/native"
+release="${tmp}/release"
+boot="${tmp}/boot"
+mkdir -p "${native}" "${release}" "${boot}"
+
+printf '\037\213\010\000' > "${native}/initramfs.cpio.gz.fixture"
+printf '\050\265\057\375' > "${native}/initramfs.cpio.zst.fixture"
+printf '\004\042\115\030' > "${native}/initramfs.cpio.lz4.fixture"
+
+[ "$(initramfs_detect_codec "${native}/initramfs.cpio.gz.fixture")" = gzip ] || fail "gzip magic"
+[ "$(initramfs_detect_codec "${native}/initramfs.cpio.zst.fixture")" = zstd ] || fail "zstd magic"
+[ "$(initramfs_detect_codec "${native}/initramfs.cpio.lz4.fixture")" = lz4 ] || fail "lz4 magic"
+
+cp "${native}/initramfs.cpio.zst.fixture" "${tmp}/initramfs.cpio.gz"
+if initramfs_assert_codec_identity "${tmp}/initramfs.cpio.gz" 2>/dev/null; then
+  fail "expected identity failure for zstd bytes under .gz name"
+fi
+
+cp "${native}/initramfs.cpio.zst.fixture" "${native}/initramfs.cpio.zst"
+resolved="$(initramfs_resolve_release_artifact "${native}" "${release}")"
+[ "${resolved}" = "${release}/initramfs.cpio.zst" ] || fail "resolve path: ${resolved}"
+initramfs_assert_codec_identity "${resolved}" || fail "resolved zst identity"
+base="$(basename -- "${resolved}")"
+cp "${resolved}" "${boot}/${base}"
+initramfs_assert_codec_identity "${boot}/${base}" || fail "installed boot identity"
+module_path="boot():/boot/${base}"
+case "${module_path}" in
+  *initramfs.cpio.zst) ;;
+  *) fail "module_path must use final basename: ${module_path}" ;;
+esac
+
+br="${REPO_ROOT}/scripts/build-release.sh"
+[ -f "${br}" ] || fail "missing build-release.sh"
+
+if grep -Eq 'INITRAMFS="\$\{OUT_DIR\}/initramfs\.cpio\.gz"' "${br}" \
+  && grep -Eq 'cp "\$\{native_initramfs\}" "\$\{INITRAMFS\}"' "${br}"; then
+  fail "build-release copies native zst/lz4 onto fixed initramfs.cpio.gz path"
+fi
+
+if grep -Eq 'cp "\$\{INITRAMFS\}" "\$\{MNT_ROOT\}/boot/initramfs\.cpio\.gz"' "${br}"; then
+  fail "build-release installs initramfs under hard-coded .gz name"
+fi
+
+if grep -Eq 'module_path: boot\(\):/boot/initramfs\.cpio\.gz' "${br}"; then
+  fail "build-release hard-codes Limine module_path to initramfs.cpio.gz"
+fi
+
+grep -Eq 'initramfs_resolve_release_artifact|initramfs_assert_codec_identity' "${br}" \
+  || fail "build-release must use initramfs codec identity helpers"
+
+printf 'test-initramfs-codec-identity: ok\n'


### PR DESCRIPTION
## Summary
- Preserve native initramfs codec filenames through the release artifact and boot install path.
- Generate Limine `module_path` from the installed artifact basename.
- Fail closed when initramfs magic bytes do not match their filename suffix.
- Add a hermetic codec-identity contract test and run it from the appliance check.

## Validation
- `sh -n scripts/lib/initramfs-codec-identity.sh`
- `sh -n scripts/test-initramfs-codec-identity.sh`
- `sh -n scripts/build-release.sh`
- `sh -n scripts/ci-os-appliance.sh`
- `sh scripts/test-initramfs-codec-identity.sh`
- `sh scripts/ci-os-appliance.sh`
- `git diff --check`

## Proof boundary
This is hermetic script and synthetic-magic validation only. It does not prove a production image build, Limine boot, QEMU, cross-architecture behavior, or kernel initrd loading.