### PR TITLE
🧪 Add tests for parseKind function

### DIFF
--- a/system/alpenglow-ctl/src/network.zig
+++ b/system/alpenglow-ctl/src/network.zig
@@ -383,3 +383,12 @@ pub fn run() !void {
         std.process.exit(1);
     };
 }
+
+test "parseKind handles valid and edge case inputs" {
+    const testing = std.testing;
+    try testing.expectEqualStrings("ethernet", parseKind(null));
+    try testing.expectEqualStrings("ethernet", parseKind("abc"));
+    try testing.expectEqualStrings("ethernet", parseKind("1"));
+    try testing.expectEqualStrings("loopback", parseKind("772"));
+    try testing.expectEqualStrings("ethernet", parseKind("-1"));
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for missing edge case tests in parseKind.
📊 **Coverage:** Covered null inputs, unrecognized strings ('abc'), unmatched valid numbers ('1', '-1'), and matched valid numbers ('772').
✨ **Result:** Improved test coverage by verifying edge cases and valid paths in the parseKind utility function.

---
*PR created automatically by Jules for task [9124785773875008005](https://jules.google.com/task/9124785773875008005) started by @undivisible*