### PR TITLE
🔒 Fix Command Injection / Path Traversal via LUKS state key

### DIFF
--- a/system/backends/appliance/initramfs/init
+++ b/system/backends/appliance/initramfs/init
@@ -45,6 +45,14 @@ valid_state_path() {
   esac
 }
 
+valid_key_path() {
+  case "$1" in
+    *..*) return 1 ;;
+    /*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 rescue_or_halt() {
   msg="$1"
   echo "${msg}" >&2
@@ -60,6 +68,9 @@ if [ -n "${ALPENGLOW_IMAGE}" ] && ! valid_image_path "${ALPENGLOW_IMAGE}"; then
 fi
 if [ -n "${ALPENGLOW_STATE}" ] && ! valid_state_path "${ALPENGLOW_STATE}"; then
   rescue_or_halt "Alpenglow: rejected alpenglow.state=${ALPENGLOW_STATE}"
+fi
+if [ -n "${ALPENGLOW_STATE_KEY}" ] && ! valid_key_path "${ALPENGLOW_STATE_KEY}"; then
+  rescue_or_halt "Alpenglow: rejected alpenglow.state.key=${ALPENGLOW_STATE_KEY}"
 fi
 
 for m in erofs squashfs bcachefs dm-crypt virtio-blk virtio-net \

--- a/system/backends/appliance/scripts/mount-state.sh
+++ b/system/backends/appliance/scripts/mount-state.sh
@@ -19,6 +19,14 @@ for arg in $(cat /proc/cmdline 2>/dev/null); do
   esac
 done
 
+valid_key_path() {
+  case "$1" in
+    *..*) return 1 ;;
+    /*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 state_block_dev() {
   spec="$1"
   case "${spec}" in
@@ -69,8 +77,16 @@ open_luks_state() {
   fi
 
   modprobe dm-crypt 2>/dev/null || true
-  if [ -n "${STATE_KEY}" ] && [ -r "${STATE_KEY}" ]; then
-    cryptsetup luksOpen "${dev}" alpenglow-state --key-file "${STATE_KEY}" || return 1
+  if [ -n "${STATE_KEY}" ]; then
+    if ! valid_key_path "${STATE_KEY}"; then
+      echo "invalid key path: ${STATE_KEY}" >&2
+      return 1
+    fi
+    if [ -r "${STATE_KEY}" ]; then
+      cryptsetup luksOpen "${dev}" alpenglow-state --key-file "${STATE_KEY}" || return 1
+    else
+      cryptsetup luksOpen "${dev}" alpenglow-state || return 1
+    fi
   else
     cryptsetup luksOpen "${dev}" alpenglow-state || return 1
   fi


### PR DESCRIPTION
🎯 What: Added path validation for the LUKS key file paths in the initramfs and mount-state scripts.
⚠️ Risk: An attacker who can control kernel command-line arguments could potentially supply a malicious path containing `..` or relative components, leading to path traversal or reading unintended files when `cryptsetup` processes `--key-file`.
🛡️ Solution: Implemented `valid_key_path()` to explicitly reject any path containing `..` and to ensure that the key file path is absolute (must start with `/`). This guarantees that only valid and expected local paths are passed to `cryptsetup`.

---
*PR created automatically by Jules for task [2940117606126580488](https://jules.google.com/task/2940117606126580488) started by @undivisible*