### PR TITLE
perf(site): remove mismatched v86 Wasm preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "dev": "astro dev",
     "build:v86": "V86_SSH=1 sh scripts/build-v86-initramfs.sh",
     "build:v86:local": "sh scripts/build-v86-initramfs.sh",
+    "test:site": "sh scripts/test-site-v86-preload.sh",
     "build:site": "sh scripts/write-site-version.sh && astro check --minimumSeverity error && astro build",
     "build": "V86_SSH=1 sh scripts/build-v86-initramfs.sh && bun run build:site",
     "preview": "astro preview",

--- a/scripts/test-site-v86-preload.sh
+++ b/scripts/test-site-v86-preload.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Guard against preloading a URL that the runtime intentionally versions.
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+PAGE="$ROOT_DIR/src/pages/index.astro"
+SHELL="$ROOT_DIR/src/shell.js"
+
+if grep -Fq 'href="/v86/v86.wasm"' "$PAGE" && grep -Fq 'asset("/v86/v86.wasm")' "$SHELL"; then
+  printf '%s\n' 'index preloads an unversioned v86 Wasm URL while runtime requests a versioned URL' >&2
+  exit 1
+fi

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,6 @@
     <meta name="description" content="Alpenglow is an immutable RAM-root Linux distribution with persistent bcachefs-backed state." />
     <link rel="icon" href="/favicon.png" type="image/png" />
     <link rel="preload" href="/fonts/geist-mono-latin-400-normal.woff2" as="font" type="font/woff2" crossorigin />
-    <link rel="preload" href="/v86/v86.wasm" as="fetch" crossorigin />
     <title>Alpenglow</title>
   </head>
   <body class="m-0 h-full overflow-hidden bg-black text-white antialiased">


### PR DESCRIPTION
## Summary
- remove the unversioned v86 Wasm preload whose URL differs from the runtime cache-busted request
- add a source-level guard against restoring that cache-key mismatch

## Verification
- `sh scripts/test-site-v86-preload.sh` (RED before the removal, GREEN after)
- `bun run test:site`
- `bun run build:site` (Astro check + static build)
- `git diff --check`

## Proof boundary
Static build/source proof only; no browser network trace or live-site deployment was performed.