### PR TITLE
test(oil): cover PackageIndex loop semantics

### DIFF
--- a/system/oil/src/system/registry/mod.rs
+++ b/system/oil/src/system/registry/mod.rs
@@ -32,9 +32,6 @@ impl PackageIndex {
             for prov in &pkg.provides {
                 provides_index.entry(prov.clone()).or_insert(i);
             }
-        }
-
-        for (i, pkg) in packages.iter().enumerate() {
             name_index.entry(pkg.name.clone()).or_insert(i);
         }
 
@@ -183,6 +180,56 @@ mod tests {
         assert!(index.find("libssl3").is_some());
         assert!(index.find("libssl").is_some());
         assert!(index.find("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_package_index_preserves_first_match_and_input_order() {
+        let packages = vec![
+            PackageMetadata {
+                name: "duplicate".to_string(),
+                version: "first".to_string(),
+                description: String::new(),
+                download_url: String::new(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec!["virtual".to_string(), "shared".to_string()],
+            },
+            PackageMetadata {
+                name: "virtual".to_string(),
+                version: "named".to_string(),
+                description: String::new(),
+                download_url: String::new(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec!["shared".to_string()],
+            },
+            PackageMetadata {
+                name: "duplicate".to_string(),
+                version: "second".to_string(),
+                description: String::new(),
+                download_url: String::new(),
+                sha256: None,
+                installed_size: 0,
+                depends: vec![],
+                provides: vec![],
+            },
+        ];
+        let index = PackageIndex::new(packages);
+
+        assert_eq!(
+            index
+                .packages
+                .iter()
+                .map(|pkg| pkg.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["first", "named", "second"]
+        );
+        assert_eq!(index.find("duplicate").unwrap().version, "first");
+        assert_eq!(index.find("virtual").unwrap().version, "named");
+        assert_eq!(index.find("shared").unwrap().version, "first");
+        assert!(PackageIndex::new(vec![]).find("").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- provides a minimal, current-base replacement for #145 because that PR disallows maintainer edits
- combines the two `PackageIndex::new` index-building passes without changing first-match precedence
- adds a focused regression test for duplicate names, name-vs-provider precedence, duplicate providers, input order, and empty input

The original PR’s claimed benchmark has no committed harness or reproducible results, and its only behavioral change has no regression coverage. The repository only has host/QEMU boot benchmarks, not Rust microbenchmark infrastructure, so this PR intentionally does not add an ad-hoc timing benchmark.

## Validation
- `cargo test -p oil test_package_index_preserves_first_match_and_input_order`
- `rustfmt --check --config skip_children=true system/oil/src/system/registry/mod.rs`
- `cargo clippy -p oil --all-targets -- -D warnings`
- `./scripts/ci-rust-core.sh`
- `git diff --check`

The regression test was mutation-checked RED by changing provider indexing to last-match-wins; it failed with `left: "named", right: "first"`, then passed after restoring first-match behavior with the combined loop.