### PR TITLE
🧪 [testing] Add tests for insecure_mode function

### DIFF
--- a/system/oil/src/util/security.rs
+++ b/system/oil/src/util/security.rs
@@ -92,6 +92,29 @@ pub fn resolve_install_dest(prefix: Option<&Path>, relative: &Path) -> Result<Pa
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[test]
+    fn test_insecure_mode() {
+        let _lock = env_lock();
+
+        // Test when unset
+        std::env::remove_var("OIL_INSECURE_NO_VERIFY");
+        assert!(!insecure_mode());
+
+        // Test when set
+        std::env::set_var("OIL_INSECURE_NO_VERIFY", "1");
+        assert!(insecure_mode());
+
+        // Clean up
+        std::env::remove_var("OIL_INSECURE_NO_VERIFY");
+    }
 
     #[test]
     fn allows_alpine_cdn() {


### PR DESCRIPTION
🎯 **What:** The `insecure_mode` function in `system/oil/src/util/security.rs` lacked test coverage.
📊 **Coverage:** Added tests to verify the function correctly reads the `OIL_INSECURE_NO_VERIFY` environment variable, returning `true` when set and `false` when unset.
✨ **Result:** Increased test coverage and ensured the reliable behavior of the insecure mode toggle.

---
*PR created automatically by Jules for task [6201451082777335778](https://jules.google.com/task/6201451082777335778) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production behavior modifications.
> 
> **Overview**
> Adds **`test_insecure_mode`** in `security.rs` to assert `insecure_mode()` is **false** when `OIL_INSECURE_NO_VERIFY` is unset and **true** when it is set, with cleanup after each case.
> 
> Introduces a shared **`ENV_MUTEX`** / **`env_lock()`** so tests that mutate process environment variables do not race when the suite runs in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4805bd06abe5bd654b4258e6ad87b064d30ef953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->