### PR TITLE
🧪 [Testing] Add test for default_live_source

### DIFF
--- a/system/installer/src/lib.rs
+++ b/system/installer/src/lib.rs
@@ -189,6 +189,14 @@ mod tests {
     use tempfile::{tempdir, NamedTempFile};
 
     #[test]
+    fn test_default_live_source() {
+        assert_eq!(
+            default_live_source(),
+            PathBuf::from("/run/alpenglow/alpenglow.img.zst")
+        );
+    }
+
+    #[test]
     fn test_parse_install_args_zero_args() {
         let args: Vec<&str> = vec![];
         let (source, target) = parse_install_args(args);


### PR DESCRIPTION
🎯 **What:** Added a unit test for the default_live_source function to ensure it returns the expected default path.
📊 **Coverage:** The happy path for default_live_source is now tested.
✨ **Result:** Test coverage improved.

---
*PR created automatically by Jules for task [17885840937827272776](https://jules.google.com/task/17885840937827272776) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or installer behavior modifications.
> 
> **Overview**
> Adds **`test_default_live_source`** in `system/installer/src/lib.rs` so `default_live_source()` is asserted to return `/run/alpenglow/alpenglow.img.zst`.
> 
> This pins the live-install default image path that `parse_install_args` and `parse_installer_args` already rely on when no source is given; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e2d39c45601611fbeeed436edca872b375bb511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->