### PR TITLE
🧹 [Code Health] Extract nested file processing logic in `process_tar_entry`

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -3,11 +3,11 @@ mod install;
 mod recipe;
 mod signal;
 mod system;
-pub mod util;
 #[cfg(feature = "wax")]
 mod tap;
 #[cfg(test)]
 mod test_support;
+pub mod util;
 
 use clap::{Parser, Subcommand};
 use error::Result;
@@ -205,11 +205,7 @@ fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> Packag
             };
             match result {
                 Ok(index) => {
-                    eprintln!(
-                        "Loaded {} packages from tap {}",
-                        index.packages.len(),
-                        name
-                    );
+                    eprintln!("Loaded {} packages from tap {}", index.packages.len(), name);
                     all.extend(index.packages);
                 }
                 Err(e) => eprintln!("warning: failed to load tap {name}: {e}"),
@@ -323,7 +319,12 @@ fn run_system(command: SystemCommands) -> Result<()> {
                     );
                 } else {
                     install_package(pkg, &dest)?;
-                    println!("Installed {} {} into {}", pkg.name, pkg.version, dest.display());
+                    println!(
+                        "Installed {} {} into {}",
+                        pkg.name,
+                        pkg.version,
+                        dest.display()
+                    );
                 }
             }
             Ok(())
@@ -747,10 +748,7 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         let actual = format!("{:x}", hasher.finalize());
         let expected = expected.trim().to_ascii_lowercase();
         if actual != expected {
-            return Err(error::OilError::ChecksumMismatch {
-                expected,
-                actual,
-            });
+            return Err(error::OilError::ChecksumMismatch { expected, actual });
         }
     }
 

--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -3,11 +3,11 @@ mod install;
 mod recipe;
 mod signal;
 mod system;
+pub mod util;
 #[cfg(feature = "wax")]
 mod tap;
 #[cfg(test)]
 mod test_support;
-pub mod util;
 
 use clap::{Parser, Subcommand};
 use error::Result;
@@ -205,7 +205,11 @@ fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> Packag
             };
             match result {
                 Ok(index) => {
-                    eprintln!("Loaded {} packages from tap {}", index.packages.len(), name);
+                    eprintln!(
+                        "Loaded {} packages from tap {}",
+                        index.packages.len(),
+                        name
+                    );
                     all.extend(index.packages);
                 }
                 Err(e) => eprintln!("warning: failed to load tap {name}: {e}"),
@@ -319,12 +323,7 @@ fn run_system(command: SystemCommands) -> Result<()> {
                     );
                 } else {
                     install_package(pkg, &dest)?;
-                    println!(
-                        "Installed {} {} into {}",
-                        pkg.name,
-                        pkg.version,
-                        dest.display()
-                    );
+                    println!("Installed {} {} into {}", pkg.name, pkg.version, dest.display());
                 }
             }
             Ok(())
@@ -748,7 +747,10 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         let actual = format!("{:x}", hasher.finalize());
         let expected = expected.trim().to_ascii_lowercase();
         if actual != expected {
-            return Err(error::OilError::ChecksumMismatch { expected, actual });
+            return Err(error::OilError::ChecksumMismatch {
+                expected,
+                actual,
+            });
         }
     }
 

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -238,38 +238,66 @@ fn process_tar_entry<R: std::io::Read>(
 
     let kind = entry.header().entry_type();
     if kind.is_dir() {
-        if !created_dirs.contains(&dest) {
-            std::fs::create_dir_all(&dest)?;
-            created_dirs.insert(dest.clone());
-        }
-        dirs.push(dest);
+        process_dir(&dest, dirs, created_dirs)?;
     } else if kind.is_symlink() {
-        if let Some(link_target) = entry.link_name()? {
-            if !is_safe_symlink(link_target.as_ref(), &dest, dest_dir) {
-                return Err(OilError::Install(format!(
-                    "Unsafe symlink target {:?} for {:?}",
-                    link_target, dest
-                )));
-            }
-            let _ = std::fs::remove_file(&dest);
-            let _ = std::fs::remove_dir_all(&dest);
-            #[cfg(unix)]
-            std::os::unix::fs::symlink(link_target.as_ref(), &dest)?;
-            files.push(dest);
-        }
+        process_symlink(&entry, &dest, dest_dir, files)?;
     } else if kind.is_hard_link() {
         return Err(OilError::Install(format!(
             "hard links are not allowed in APK payloads: {stripped}"
         )));
     } else if kind.is_file() {
-        entry.unpack(&dest)?;
-        files.push(dest);
+        process_file(&mut entry, &dest, files)?;
     } else {
         return Err(OilError::Install(format!(
             "unsupported tar entry type for {stripped}"
         )));
     }
 
+    Ok(())
+}
+
+fn process_dir(
+    dest: &Path,
+    dirs: &mut Vec<PathBuf>,
+    created_dirs: &mut std::collections::HashSet<PathBuf>,
+) -> Result<()> {
+    if !created_dirs.contains(dest) {
+        std::fs::create_dir_all(dest)?;
+        created_dirs.insert(dest.to_path_buf());
+    }
+    dirs.push(dest.to_path_buf());
+    Ok(())
+}
+
+fn process_symlink<R: std::io::Read>(
+    entry: &tar::Entry<'_, R>,
+    dest: &Path,
+    dest_dir: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    if let Some(link_target) = entry.link_name()? {
+        if !is_safe_symlink(link_target.as_ref(), dest, dest_dir) {
+            return Err(OilError::Install(format!(
+                "Unsafe symlink target {:?} for {:?}",
+                link_target, dest
+            )));
+        }
+        let _ = std::fs::remove_file(dest);
+        let _ = std::fs::remove_dir_all(dest);
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(link_target.as_ref(), dest)?;
+        files.push(dest.to_path_buf());
+    }
+    Ok(())
+}
+
+fn process_file<R: std::io::Read>(
+    entry: &mut tar::Entry<'_, R>,
+    dest: &Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<()> {
+    entry.unpack(dest)?;
+    files.push(dest.to_path_buf());
     Ok(())
 }
 
@@ -372,17 +400,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 0 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -400,23 +400,17 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(
-            err_msg.contains("APK has 0 gzip streams, expected 3"),
-            "Unexpected error: {}",
-            err_msg
-        );
+        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic


### PR DESCRIPTION
🎯 **What:** Extracted nested file type handling logic inside `process_tar_entry` into separate smaller functions (`process_dir`, `process_symlink`, `process_file`).
💡 **Why:** Reduces the complexity of the main `process_tar_entry` loop, improving readability and maintainability.
✅ **Verification:** Verified by running `cargo test --manifest-path system/oil/Cargo.toml --bin oil`.
✨ **Result:** A cleaner and more modular implementation of the tar entry processing logic.

---
*PR created automatically by Jules for task [8681113897497515839](https://jules.google.com/task/8681113897497515839) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in APK extraction with preserved symlink checks and error paths; no new logic or API surface.
> 
> **Overview**
> **Refactors** APK data-tar handling in `process_tar_entry` by moving per-entry-type logic into `process_dir`, `process_symlink`, and `process_file`.
> 
> `process_tar_entry` now only branches on tar entry kind and delegates; directory creation/deduping, symlink safety via `is_safe_symlink`, and file unpack behavior are unchanged, just relocated. Hard-link and unsupported-type errors stay in the main function.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20da55fb76eaf2073e8895a01e585eb0e521dd40. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->