### PR TITLE
🧪 Add test for renderResponse function

### DIFF
--- a/site/test/site.test.ts
+++ b/site/test/site.test.ts
@@ -98,4 +98,12 @@ describe("alpenglow site", () => {
       await server.stop(true);
     }
   });
+
+  test("renderResponse returns a valid Response object", async () => {
+    const req = new Request("http://localhost/");
+    const res = await renderResponse(req);
+    expect(res).toBeInstanceOf(Response);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/html; charset=utf-8");
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for renderResponse function in site/src/document.ts.
📊 **Coverage:** Tests that renderResponse returns a valid Response object with correct status 200, and correct content-type header.
✨ **Result:** Increased test coverage and confidence in the renderResponse utility.

---
*PR created automatically by Jules for task [6217379307280541109](https://jules.google.com/task/6217379307280541109) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds a **direct unit test** for `renderResponse` in `site/test/site.test.ts`, asserting it returns a `Response` with status **200** and `content-type` **`text/html; charset=utf-8`**.
> 
> This complements existing integration coverage via `GET /` and `renderDocument` tests by exercising the helper without going through the HTTP server handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cabd2691e719ff0527bd74045242d01fddb541fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->