### PR TITLE
🧹 Remove dead code in command dispatcher

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -3,11 +3,11 @@ mod install;
 mod recipe;
 mod signal;
 mod system;
+pub mod util;
 #[cfg(feature = "wax")]
 mod tap;
 #[cfg(test)]
 mod test_support;
-pub mod util;
 
 use clap::{Parser, Subcommand};
 use error::Result;
@@ -200,7 +200,11 @@ fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> Packag
             };
             match result {
                 Ok(index) => {
-                    eprintln!("Loaded {} packages from tap {}", index.packages.len(), name);
+                    eprintln!(
+                        "Loaded {} packages from tap {}",
+                        index.packages.len(),
+                        name
+                    );
                     all.extend(index.packages);
                 }
                 Err(e) => eprintln!("warning: failed to load tap {name}: {e}"),
@@ -314,12 +318,7 @@ fn run_system(command: SystemCommands) -> Result<()> {
                     );
                 } else {
                     install_package(pkg, &dest)?;
-                    println!(
-                        "Installed {} {} into {}",
-                        pkg.name,
-                        pkg.version,
-                        dest.display()
-                    );
+                    println!("Installed {} {} into {}", pkg.name, pkg.version, dest.display());
                 }
             }
             Ok(())
@@ -743,7 +742,10 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         let actual = format!("{:x}", hasher.finalize());
         let expected = expected.trim().to_ascii_lowercase();
         if actual != expected {
-            return Err(error::OilError::ChecksumMismatch { expected, actual });
+            return Err(error::OilError::ChecksumMismatch {
+                expected,
+                actual,
+            });
         }
     }
 

--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -3,11 +3,11 @@ mod install;
 mod recipe;
 mod signal;
 mod system;
-pub mod util;
 #[cfg(feature = "wax")]
 mod tap;
 #[cfg(test)]
 mod test_support;
+pub mod util;
 
 use clap::{Parser, Subcommand};
 use error::Result;
@@ -167,11 +167,6 @@ fn dispatch_command(cmd: Commands) -> Result<()> {
     }
 }
 
-#[allow(dead_code)]
-fn run_command(cmd: Commands) -> Result<()> {
-    dispatch_command(cmd)
-}
-
 #[cfg(feature = "wax")]
 fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> PackageIndex {
     let taps = match tap::Taps::new() {
@@ -205,11 +200,7 @@ fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> Packag
             };
             match result {
                 Ok(index) => {
-                    eprintln!(
-                        "Loaded {} packages from tap {}",
-                        index.packages.len(),
-                        name
-                    );
+                    eprintln!("Loaded {} packages from tap {}", index.packages.len(), name);
                     all.extend(index.packages);
                 }
                 Err(e) => eprintln!("warning: failed to load tap {name}: {e}"),
@@ -323,7 +314,12 @@ fn run_system(command: SystemCommands) -> Result<()> {
                     );
                 } else {
                     install_package(pkg, &dest)?;
-                    println!("Installed {} {} into {}", pkg.name, pkg.version, dest.display());
+                    println!(
+                        "Installed {} {} into {}",
+                        pkg.name,
+                        pkg.version,
+                        dest.display()
+                    );
                 }
             }
             Ok(())
@@ -747,10 +743,7 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         let actual = format!("{:x}", hasher.finalize());
         let expected = expected.trim().to_ascii_lowercase();
         if actual != expected {
-            return Err(error::OilError::ChecksumMismatch {
-                expected,
-                actual,
-            });
+            return Err(error::OilError::ChecksumMismatch { expected, actual });
         }
     }
 
@@ -869,10 +862,7 @@ mod tests {
             let cmd = cli.command.expect("subcommand");
             assert_eq!(cmd, want, "argv: {argv:?}");
 
-            // Do not execute run_command in tests for commands that require network
-            // or modify the filesystem extensively (like tap add, upgrade, update, etc).
             // We just want to test CLI parsing aliases.
-            // run_command(cmd).expect("run_command");
         }
     }
 

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -372,23 +372,17 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(
-            err_msg.contains("APK has 0 gzip streams, expected 3"),
-            "Unexpected error: {}",
-            err_msg
-        );
+        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes(
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -372,17 +372,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 0 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic


### PR DESCRIPTION
🎯 **What:** Removed unused `run_command` function and related commented-out test code.
💡 **Why:** Reduces code clutter and improves maintainability.
✅ **Verification:** Verified by running all unit tests, clippy and rustfmt.
✨ **Result:** A cleaner command dispatcher implementation.

---
*PR created automatically by Jules for task [15751846360014343733](https://jules.google.com/task/15751846360014343733) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or CLI behavior changes; only removes unused code and test comments.
> 
> **Overview**
> Removes the unused `run_command` helper in `main.rs`, which only forwarded to `dispatch_command` while `main` already invokes `dispatch_command` directly.
> 
> In `cli_parses_command_aliases`, drops stale comments about not calling `run_command` in tests and the commented-out `run_command(cmd)` line, leaving alias parsing assertions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 722bf8d15807a9455bc853df41497c708059680c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->