### PR TITLE
🧪 [Testing] Add tests for From<serde_norway::Error> for OilError

### DIFF
--- a/system/oil/src/error.rs
+++ b/system/oil/src/error.rs
@@ -173,4 +173,18 @@ mod tests {
             _ => panic!("Expected OilError::Http"),
         }
     }
+
+    #[test]
+    fn test_from_serde_norway_error() {
+        let yaml_err: std::result::Result<serde_json::Value, serde_norway::Error> =
+            serde_norway::from_str("{");
+        let orig_err = yaml_err.unwrap_err();
+        let err_msg = orig_err.to_string();
+
+        let err: OilError = orig_err.into();
+        match err {
+            OilError::Recipe(msg) => assert_eq!(msg, err_msg),
+            _ => panic!("Expected OilError::Recipe"),
+        }
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for `From<serde_norway::Error>` trait implementation in `OilError`.
📊 **Coverage:** Covered the conversion of a `serde_norway::Error` to an `OilError::Recipe` using an invalid YAML string.
✨ **Result:** Increased test coverage by ensuring the error is properly mapped to an `OilError::Recipe`.

---
*PR created automatically by Jules for task [3751945460645428693](https://jules.google.com/task/3751945460645428693) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in error.rs; no production behavior modified.
> 
> **Overview**
> Adds **`test_from_serde_norway_error`** in `system/oil/src/error.rs`, following the same pattern as the other `From` conversion tests.
> 
> The test parses invalid YAML via `serde_norway::from_str("{")` and asserts the error converts to **`OilError::Recipe`** with the original message preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb5ae2de42ba914c15a3e4f0e9e2844a62ab428d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->