### PR TITLE
🧪 [Testing] Add tests for resolve_install_dest

### DIFF
--- a/system/oil/src/util/security.rs
+++ b/system/oil/src/util/security.rs
@@ -127,10 +127,20 @@ mod tests {
 
     #[test]
     fn resolve_install_dest_without_prefix() {
-        assert_eq!(
-            resolve_install_dest(None, Path::new("/usr/local/bin")).unwrap(),
-            PathBuf::from("/usr/local/bin")
-        );
+        if std::env::var_os("OIL_SYSTEM_PREFIX").is_some() {
+            let exe = std::env::current_exe().expect("current test binary");
+            let status = std::process::Command::new(exe)
+                .args(["resolve_install_dest_without_prefix", "--exact", "--nocapture"])
+                .env_remove("OIL_SYSTEM_PREFIX")
+                .status()
+                .expect("spawn test subprocess");
+            assert!(status.success());
+        } else {
+            assert_eq!(
+                resolve_install_dest(None, Path::new("/usr/local/bin")).unwrap(),
+                PathBuf::from("/usr/local/bin")
+            );
+        }
     }
 
     #[test]

--- a/system/oil/src/util/security.rs
+++ b/system/oil/src/util/security.rs
@@ -116,4 +116,25 @@ mod tests {
             PathBuf::from("/usr/local")
         );
     }
+
+    #[test]
+    fn resolve_install_dest_with_custom_prefix() {
+        assert_eq!(
+            resolve_install_dest(Some(Path::new("/custom/prefix")), Path::new("/usr/local/bin")).unwrap(),
+            PathBuf::from("/custom/prefix/usr/local/bin")
+        );
+    }
+
+    #[test]
+    fn resolve_install_dest_without_prefix() {
+        assert_eq!(
+            resolve_install_dest(None, Path::new("/usr/local/bin")).unwrap(),
+            PathBuf::from("/usr/local/bin")
+        );
+    }
+
+    #[test]
+    fn resolve_install_dest_invalid_relative() {
+        assert!(resolve_install_dest(Some(Path::new("/custom/prefix")), Path::new("/etc/bin")).is_err());
+    }
 }


### PR DESCRIPTION
🎯 **What:** Added tests for `resolve_install_dest` in `security.rs`.\n📊 **Coverage:** Covered custom prefix behavior, fallback to relative path without prefix, and error handling for invalid paths.\n✨ **Result:** Increased test coverage and validation confidence for destination path resolution.

---
*PR created automatically by Jules for task [16636469208239639828](https://jules.google.com/task/16636469208239639828) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production logic modified; the subprocess branch is slightly unusual but still low risk.
> 
> **Overview**
> Adds unit tests in `security.rs` for **`resolve_install_dest`**, which was previously only exercised indirectly through install-path validation tests.
> 
> Coverage includes joining an explicit custom prefix with an allowed relative path (`/usr/local/bin` → `/custom/prefix/usr/local/bin`), the no-prefix path when `OIL_SYSTEM_PREFIX` is unset (expects the validated relative path unchanged), and rejection when the relative path fails `validate_install_dest` (e.g. `/etc/bin`).
> 
> The no-prefix case branches when `OIL_SYSTEM_PREFIX` is set at test runtime: it re-runs the same test in a child process with that env var cleared so behavior does not depend on the parent’s environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2cace9271a34607a9c6f598ece38663ff79f8eb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->