### PR TITLE
🔒 Fix QEMU shell string interpolation vulnerability

### DIFF
--- a/system/backends/appliance/scripts/qemu.sh
+++ b/system/backends/appliance/scripts/qemu.sh
@@ -21,15 +21,16 @@ command -v qemu-system-x86_64 >/dev/null 2>&1 || { echo "missing qemu-system-x86
 [ -f "${KERNEL}" ] || { echo "missing kernel: ${KERNEL}"; exit 1; }
 [ -f "${INITRAMFS}" ] || { echo "missing initramfs: ${INITRAMFS}"; exit 1; }
 
-DISPLAY="--display default"
-INPUT=""
+set -- qemu-system-x86_64 -machine "q35,accel=${ACCEL}" -m "${MEMORY_MB}" -smp 2 -no-reboot
+
 if [ "${HEADLESS}" = "1" ]; then
-  DISPLAY="-nographic"
+  set -- "$@" -nographic
 elif [ -n "${VNC}" ]; then
-  DISPLAY="-display none -vnc ${VNC}"
-  INPUT="-device virtio-gpu-pci -device virtio-keyboard-pci -device virtio-mouse-pci"
+  set -- "$@" -display none -vnc "${VNC}"
+  set -- "$@" -device virtio-gpu-pci -device virtio-keyboard-pci -device virtio-mouse-pci
 else
-  INPUT="-device virtio-gpu-pci -device virtio-keyboard-pci -device virtio-mouse-pci"
+  set -- "$@" --display default
+  set -- "$@" -device virtio-gpu-pci -device virtio-keyboard-pci -device virtio-mouse-pci
 fi
 
 # Find OVMF firmware for EFI boot
@@ -41,12 +42,10 @@ if [ "${EFI}" = "1" ]; then
   done
 fi
 
-QEMU_CMD="qemu-system-x86_64 -machine q35,accel=${ACCEL} -m ${MEMORY_MB} -smp 2 -no-reboot ${DISPLAY} ${INPUT}"
-
 if [ -n "${OVMF}" ]; then
   # Try OVMF + kernel EFI stub. If firmware fails (e.g. EFI stub missing), fall through.
-  ${QEMU_CMD} -bios "${OVMF}" -kernel "${KERNEL}" -initrd "${INITRAMFS}" -append "${KERNEL_CMDLINE}" 2>/dev/null && exit 0 || true
+  "$@" -bios "${OVMF}" -kernel "${KERNEL}" -initrd "${INITRAMFS}" -append "${KERNEL_CMDLINE}" 2>/dev/null && exit 0 || true
 fi
 
 # SeaBIOS / direct kernel boot (no EFI stub or OVMF unavailable)
-exec ${QEMU_CMD} -kernel "${KERNEL}" -initrd "${INITRAMFS}" -append "${KERNEL_CMDLINE}"
+exec "$@" -kernel "${KERNEL}" -initrd "${INITRAMFS}" -append "${KERNEL_CMDLINE}"


### PR DESCRIPTION
🎯 **What:** The QEMU boot script was previously constructing the command as a space-separated string and relying on unquoted shell interpolation to expand it.

⚠️ **Risk:** Variables could contain spaces or shell metacharacters, leading to argument injection vulnerabilities and splitting on spaces instead of handling distinct arguments.

🛡️ **Solution:** The script has been updated to use positional arguments (`set --`) to build an array of command line arguments. This ensures variables like `VNC` or `MEMORY_MB` are treated strictly as single string arguments, eliminating the risk of arbitrary argument injection when running QEMU.

---
*PR created automatically by Jules for task [13071830864869611629](https://jules.google.com/task/13071830864869611629) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev/CI QEMU wrapper only; behavior should match prior paths while reducing shell metacharacter risk in user-controlled env vars.
> 
> **Overview**
> **Hardens QEMU launch** in `system/backends/appliance/scripts/qemu.sh` by replacing a single interpolated `QEMU_CMD` string with incremental `set --` / `"$@"` so env-driven values (`VNC`, `MEMORY_MB`, `ACCEL`, paths, kernel cmdline) stay one argv element each.
> 
> Display/headless/VNC branches now append flags and virtio devices via the same positional-arg pattern; OVMF attempt and final `exec` invoke `"$@"` instead of unquoted expansion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565108b09ab4a6219deea05f8012487031727e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->