### PR TITLE
🔒 Add checksum validation for toybox download

### DIFF
--- a/scripts/build-aarch64-desktop.sh
+++ b/scripts/build-aarch64-desktop.sh
@@ -31,7 +31,19 @@ require_cmd file
 require_cmd gzip
 require_cmd lz4
 require_cmd tar
-require_cmd sha256sum
+
+EXPECTED_SHA256="223b5ff5929371225d0bc62fb3b99a148692295fb6f85ad86bb924f689a55ea4"
+
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  else
+    echo "missing sha256sum or shasum" >&2
+    exit 1
+  fi
+}
 
 mkdir -p "${OUT_DIR}"
 if [ ! -s "${KERNEL}" ]; then
@@ -39,15 +51,23 @@ if [ ! -s "${KERNEL}" ]; then
   cp "${OUT_DIR}/vmlinuz" "${KERNEL}"
 fi
 
-if [ ! -x "${OUT_DIR}/toybox-aarch64" ]; then
-  curl -fsSL -o "${OUT_DIR}/toybox-aarch64" "https://landley.net/bin/toybox/latest/toybox-aarch64"
-  EXPECTED_SHA256="223b5ff5929371225d0bc62fb3b99a148692295fb6f85ad86bb924f689a55ea4"
-  if ! echo "${EXPECTED_SHA256}  ${OUT_DIR}/toybox-aarch64" | sha256sum -c - >/dev/null 2>&1; then
+TOYBOX_BIN="${OUT_DIR}/toybox-aarch64"
+
+if [ ! -x "${TOYBOX_BIN}" ]; then
+  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/latest/toybox-aarch64"
+  chmod 755 "${TOYBOX_BIN}"
+fi
+
+if [ "$(sha256_of "${TOYBOX_BIN}")" != "${EXPECTED_SHA256}" ]; then
+  echo "Checksum mismatch for toybox-aarch64; re-downloading..." >&2
+  rm -f "${TOYBOX_BIN}"
+  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/latest/toybox-aarch64"
+  chmod 755 "${TOYBOX_BIN}"
+  if [ "$(sha256_of "${TOYBOX_BIN}")" != "${EXPECTED_SHA256}" ]; then
     echo "ERROR: Checksum validation failed for toybox-aarch64" >&2
-    rm -f "${OUT_DIR}/toybox-aarch64"
+    rm -f "${TOYBOX_BIN}"
     exit 1
   fi
-  chmod 755 "${OUT_DIR}/toybox-aarch64"
 fi
 file "${OUT_DIR}/toybox-aarch64" | grep -q 'aarch64' || { echo "not aarch64: ${OUT_DIR}/toybox-aarch64" >&2; exit 1; }
 rm -rf "${ROOTFS}"

--- a/scripts/build-aarch64-desktop.sh
+++ b/scripts/build-aarch64-desktop.sh
@@ -31,6 +31,7 @@ require_cmd file
 require_cmd gzip
 require_cmd lz4
 require_cmd tar
+require_cmd sha256sum
 
 mkdir -p "${OUT_DIR}"
 if [ ! -s "${KERNEL}" ]; then
@@ -40,6 +41,12 @@ fi
 
 if [ ! -x "${OUT_DIR}/toybox-aarch64" ]; then
   curl -fsSL -o "${OUT_DIR}/toybox-aarch64" "https://landley.net/bin/toybox/latest/toybox-aarch64"
+  EXPECTED_SHA256="223b5ff5929371225d0bc62fb3b99a148692295fb6f85ad86bb924f689a55ea4"
+  if ! echo "${EXPECTED_SHA256}  ${OUT_DIR}/toybox-aarch64" | sha256sum -c - >/dev/null 2>&1; then
+    echo "ERROR: Checksum validation failed for toybox-aarch64" >&2
+    rm -f "${OUT_DIR}/toybox-aarch64"
+    exit 1
+  fi
   chmod 755 "${OUT_DIR}/toybox-aarch64"
 fi
 file "${OUT_DIR}/toybox-aarch64" | grep -q 'aarch64' || { echo "not aarch64: ${OUT_DIR}/toybox-aarch64" >&2; exit 1; }

--- a/scripts/build-aarch64-desktop.sh
+++ b/scripts/build-aarch64-desktop.sh
@@ -54,14 +54,14 @@ fi
 TOYBOX_BIN="${OUT_DIR}/toybox-aarch64"
 
 if [ ! -x "${TOYBOX_BIN}" ]; then
-  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/latest/toybox-aarch64"
+  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/0.8.14/toybox-aarch64"
   chmod 755 "${TOYBOX_BIN}"
 fi
 
 if [ "$(sha256_of "${TOYBOX_BIN}")" != "${EXPECTED_SHA256}" ]; then
   echo "Checksum mismatch for toybox-aarch64; re-downloading..." >&2
   rm -f "${TOYBOX_BIN}"
-  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/latest/toybox-aarch64"
+  curl -fsSL -o "${TOYBOX_BIN}" "https://landley.net/bin/toybox/0.8.14/toybox-aarch64"
   chmod 755 "${TOYBOX_BIN}"
   if [ "$(sha256_of "${TOYBOX_BIN}")" != "${EXPECTED_SHA256}" ]; then
     echo "ERROR: Checksum validation failed for toybox-aarch64" >&2


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the missing validation of download certificates for toybox-aarch64.
⚠️ **Risk:** A man-in-the-middle attack or compromised server could serve a malicious binary, which would then be executed with the privileges of the script, leading to full system compromise.
🛡️ **Solution:** Added a hardcoded SHA256 sum for the downloaded toybox binary and enforced validation using sha256sum before proceeding.

---
*PR created automatically by Jules for task [16777096399994987333](https://jules.google.com/task/16777096399994987333) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time supply-chain hardening only; no changes to runtime services, auth, or data paths.
> 
> **Overview**
> Hardens the **aarch64 desktop** build by no longer pulling **toybox** from the floating `latest` URL; it now downloads **`0.8.14`** and checks the binary against a **pinned SHA256** before use.
> 
> Adds a portable **`sha256_of`** helper (`sha256sum` or `shasum`). If the on-disk binary fails the check (including a stale cache), the script **re-downloads once** and **fails the build** if validation still fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b81c4e6ff6c960d9091c210bebea0f80cff1db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->