### PR TITLE
🧪 [testing improvement] Add test for fileExists

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -335,9 +335,9 @@ test "MyArrayList.appendSlice" {
 test "fileExists" {
     const testing = std.testing;
 
-    // The test file itself should exist
-    try testing.expect(fileExists("system/zig-common.zig"));
+    // The test file itself should exist from the alpenglow-ctl build working directory
+    try testing.expect(fileExists("../zig-common.zig"));
 
     // A non-existent file should not exist
-    try testing.expect(!fileExists("system/nonexistent-file-for-test.zig"));
+    try testing.expect(!fileExists("../nonexistent-file-for-test.zig"));
 }

--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -331,3 +331,13 @@ test "MyArrayList.appendSlice" {
     try list.appendSlice(&[_]u8{ 4, 5 });
     try std.testing.expectEqualSlices(u8, &[_]u8{ 1, 2, 3, 4, 5 }, list.items());
 }
+
+test "fileExists" {
+    const testing = std.testing;
+
+    // The test file itself should exist
+    try testing.expect(fileExists("system/zig-common.zig"));
+
+    // A non-existent file should not exist
+    try testing.expect(!fileExists("system/nonexistent-file-for-test.zig"));
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for fileExists function addressed. 📊 **Coverage:** Both existing and non-existing file paths are now tested. ✨ **Result:** Improved test coverage and reliability for path operations.

---
*PR created automatically by Jules for task [6530791743681103352](https://jules.google.com/task/6530791743681103352) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior changes.
> 
> **Overview**
> Adds a **`fileExists`** unit test in `zig-common.zig` that checks a real relative path (`../zig-common.zig`) returns true and a bogus path returns false, assuming tests run from the **alpenglow-ctl** build working directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0eaa0a5ca1cb53cd9276f6f6572e5f49a1d2c26. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->