### PR TITLE
🔒 Fix shell injection vulnerability in aarch64 desktop build script

### DIFF
--- a/scripts/build-aarch64-desktop.sh
+++ b/scripts/build-aarch64-desktop.sh
@@ -48,7 +48,7 @@ mkdir -p "${ROOTFS}"
 
 CID="$(docker create --platform linux/arm64 alpine:3.21 sleep 600)"
 docker start "${CID}" >/dev/null
-docker exec "${CID}" sh -lc "apk add --no-cache ${PACKAGES} >/dev/null"
+docker exec "${CID}" sh -lc 'apk add --no-cache "$@" >/dev/null' -- ${PACKAGES}
 docker export "${CID}" | tar -C "${ROOTFS}" -xf -
 cp "${OUT_DIR}/toybox-aarch64" "${ROOTFS}/usr/bin/toybox"
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a shell injection in `scripts/build-aarch64-desktop.sh` where the `${PACKAGES}` variable was unsafely passed to `sh -c`.

⚠️ **Risk:** The potential impact if left unfixed is that an attacker who gains control over the `${PACKAGES}` variable could execute arbitrary shell commands within the docker container context, leading to potential compromise of the build environment or the resulting images.

🛡️ **Solution:** The fix passes the `${PACKAGES}` list as positional arguments (`"$@"`) to the shell script executing `apk add`, separated by `--`. This ensures that even if a package name contained malicious characters, it would be treated strictly as an argument to `apk add` rather than being evaluated by the shell as a command.

---
*PR created automatically by Jules for task [15951173444764661777](https://jules.google.com/task/15951173444764661777) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line build-script hardening with no intended change to normal desktop/desktop-full package sets; reduces compromise risk in the Docker build step.
> 
> **Overview**
> **Fixes unsafe expansion of `${PACKAGES}`** inside `docker exec … sh -lc` when seeding the Alpine arm64 rootfs in `scripts/build-aarch64-desktop.sh`.
> 
> The `apk add` step now runs a quoted inner script that takes package names via `"$@"`, with `${PACKAGES}` passed only as arguments after `--`, so package tokens are not parsed as shell syntax even if `${PACKAGES}` were ever attacker-controlled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a427d3d1763a2820c20e1d3c400d34d2554f938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->