### PR TITLE
🧪 [testing improvement] Add more tests for parse_dep_name

### DIFF
--- a/system/oil/src/system/registry/mod.rs
+++ b/system/oil/src/system/registry/mod.rs
@@ -128,10 +128,14 @@ mod tests {
         let cases = vec![
             // happy path
             ("libc6", "libc6"),
-            // with version
+            // with version and spaces
             ("libc6 (>= 2.17)", "libc6"),
             // with equals constraint
             ("rg=14.1.1-r0", "rg"),
+            // with less than constraint
+            ("rg<14.1.1-r0", "rg"),
+            // with greater than constraint
+            ("rg>14.1.1-r0", "rg"),
             // complex edge cases
             ("", ""),
             ("   ", ""),
@@ -140,6 +144,12 @@ mod tests {
             ("so:libssl.so.3", "so:libssl.so.3"),
             ("cmd:bash", "cmd:bash"),
             ("  pkg  ", "pkg"),
+            // spaces around constraints
+            ("pkg = 1.0", "pkg"),
+            ("pkg < 1.0", "pkg"),
+            ("pkg > 1.0", "pkg"),
+            // weird prefixes
+            ("!pkg", "!pkg"),
         ];
 
         for (input, expected) in cases {


### PR DESCRIPTION
🎯 **What:** Expanded the test suite for `parse_dep_name` to include missing edge cases.
📊 **Coverage:** Added coverage for '<' and '>' constraints, and spaced constraints.
✨ **Result:** Improved test reliability and coverage for dependency name parsing.

---
*PR created automatically by Jules for task [3932637054982239925](https://jules.google.com/task/3932637054982239925) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime or dependency-resolution behavior modified.
> 
> **Overview**
> Adds **test-only** coverage for `parse_dep_name` in `system/oil/src/system/registry/mod.rs`.
> 
> New cases assert parsing strips **`<` and `>`** version constraints (e.g. `rg<14.1.1-r0`), **spaced** constraint forms (`pkg = 1.0`, `pkg < 1.0`, `pkg > 1.0`), and a **`!pkg`** prefix edge case. No production code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66dc4e01fd1e3aeb870d01918c9b063f846cbc5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->