### PR TITLE
🔒 Fix eval code injection in zig wrapper scripts

### DIFF
--- a/scripts/aarch64-linux-musl-zigcc
+++ b/scripts/aarch64-linux-musl-zigcc
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
-    --target=aarch64-unknown-linux-musl) args="$args -target aarch64-linux-musl" ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    --target=aarch64-unknown-linux-musl) set -- "$@" -target aarch64-linux-musl ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig cc $args
+exec zig cc "$@"

--- a/scripts/aarch64-linux-musl-zigcxx
+++ b/scripts/aarch64-linux-musl-zigcxx
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
     --target=aarch64-unknown-linux-musl) ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig c++ -target aarch64-linux-musl $args
+exec zig c++ -target aarch64-linux-musl "$@"

--- a/scripts/x86_64-linux-musl-zigcc
+++ b/scripts/x86_64-linux-musl-zigcc
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
-    --target=x86_64-unknown-linux-musl) args="$args -target x86_64-linux-musl" ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    --target=x86_64-unknown-linux-musl) set -- "$@" -target x86_64-linux-musl ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig cc $args
+exec zig cc "$@"

--- a/scripts/x86_64-linux-musl-zigcxx
+++ b/scripts/x86_64-linux-musl-zigcxx
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
     --target=x86_64-unknown-linux-musl) ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig c++ -target x86_64-linux-musl $args
+exec zig c++ -target x86_64-linux-musl "$@"


### PR DESCRIPTION
🎯 **What:** The `eval` execution in the zigcc and zigcxx wrappers was vulnerable to arbitrary code execution if untrusted arguments were passed, due to shell escaping issues.
⚠️ **Risk:** If a malicious argument is passed during the build process, it could result in arbitrary command execution on the build machine. This is a severe security risk.
🛡️ **Solution:** Avoid `eval` entirely by shifting positional arguments to reconstruct the argument list securely and passing it directly to `exec zig ... "$@"`.

---
*PR created automatically by Jules for task [13241539894347532386](https://jules.google.com/task/13241539894347532386) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to build-only wrapper scripts that reduces security risk by eliminating eval; behavior for normal compile flags should stay the same.
> 
> **Overview**
> **Security fix** for the four `scripts/*-linux-musl-zigcc` and `*-zigcxx` shims used as cross-compiler wrappers.
> 
> They no longer build a command string with `sed` quoting and run it via `eval exec zig ...`. Arguments are rewritten in-place with the usual `for arg do; shift; set -- "$@" ...` loop, then passed to **`exec zig cc/c++ "$@"`** (with the same `--target=...` → `-target ...` mapping as before).
> 
> This closes arbitrary command execution if untrusted or malformed flags reach the wrapper during a build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 423e3c8ac96dce1c825d88e604eb1fb5bd1d4490. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->