### PR TITLE
🧹 Extract nested logic in parse_apkindex

### DIFF
--- a/system/oil/src/main.rs
+++ b/system/oil/src/main.rs
@@ -3,11 +3,11 @@ mod install;
 mod recipe;
 mod signal;
 mod system;
-pub mod util;
 #[cfg(feature = "wax")]
 mod tap;
 #[cfg(test)]
 mod test_support;
+pub mod util;
 
 use clap::{Parser, Subcommand};
 use error::Result;
@@ -199,11 +199,7 @@ fn merge_tap_packages(mut all: Vec<system::registry::PackageMetadata>) -> Packag
             };
             match result {
                 Ok(index) => {
-                    eprintln!(
-                        "Loaded {} packages from tap {}",
-                        index.packages.len(),
-                        name
-                    );
+                    eprintln!("Loaded {} packages from tap {}", index.packages.len(), name);
                     all.extend(index.packages);
                 }
                 Err(e) => eprintln!("warning: failed to load tap {name}: {e}"),
@@ -317,7 +313,12 @@ fn run_system(command: SystemCommands) -> Result<()> {
                     );
                 } else {
                     install_package(pkg, &dest)?;
-                    println!("Installed {} {} into {}", pkg.name, pkg.version, dest.display());
+                    println!(
+                        "Installed {} {} into {}",
+                        pkg.name,
+                        pkg.version,
+                        dest.display()
+                    );
                 }
             }
             Ok(())
@@ -740,10 +741,7 @@ fn install_package(pkg: &system::registry::PackageMetadata, dest: &Path) -> Resu
         let actual = format!("{:x}", hasher.finalize());
         let expected = expected.trim().to_ascii_lowercase();
         if actual != expected {
-            return Err(error::OilError::ChecksumMismatch {
-                expected,
-                actual,
-            });
+            return Err(error::OilError::ChecksumMismatch { expected, actual });
         }
     }
 

--- a/system/oil/src/system/registry/apk.rs
+++ b/system/oil/src/system/registry/apk.rs
@@ -242,6 +242,69 @@ fn tar_header_size(bytes: &[u8]) -> Result<usize> {
         .map_err(|e| OilError::Install(format!("invalid APKINDEX tar size: {e}")))
 }
 
+fn parse_apk_stanza(
+    stanza: &str,
+    mirror: &str,
+    branch: &str,
+    repo: &str,
+    arch: &str,
+) -> Option<PackageMetadata> {
+    let mut name = String::new();
+    let mut version = String::new();
+    let mut description = String::new();
+    let mut installed_size: u64 = 0;
+    let mut depends: Vec<String> = Vec::new();
+    let mut provides: Vec<String> = Vec::new();
+
+    for line in stanza.lines() {
+        if line.len() < 2 || line.as_bytes()[1] != b':' {
+            continue;
+        }
+        let key = &line[..1];
+        let val = line[2..].trim();
+
+        match key {
+            "P" => name = val.to_string(),
+            "V" => version = val.to_string(),
+            "T" => description = val.to_string(),
+            "I" => installed_size = val.parse().unwrap_or(0),
+            "D" => {
+                for dep in val.split_whitespace() {
+                    let dname = super::parse_dep_name(dep);
+                    if !dname.is_empty() && !dname.starts_with('!') {
+                        depends.push(dname.to_string());
+                    }
+                }
+            }
+            "p" => {
+                for prov in val.split_whitespace() {
+                    let pname = super::parse_dep_name(prov);
+                    if !pname.is_empty() {
+                        provides.push(pname.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    let url = format!("{mirror}/{branch}/{repo}/{arch}/{name}-{version}.apk");
+    Some(PackageMetadata {
+        name,
+        version,
+        description,
+        download_url: url,
+        sha256: None,
+        installed_size,
+        depends,
+        provides,
+    })
+}
+
 fn parse_apkindex(
     content: &str,
     mirror: &str,
@@ -257,60 +320,9 @@ fn parse_apkindex(
             continue;
         }
 
-        let mut name = String::new();
-        let mut version = String::new();
-        let mut description = String::new();
-        let mut installed_size: u64 = 0;
-        let mut depends: Vec<String> = Vec::new();
-        let mut provides: Vec<String> = Vec::new();
-
-        for line in stanza.lines() {
-            if line.len() < 2 || line.as_bytes()[1] != b':' {
-                continue;
-            }
-            let key = &line[..1];
-            let val = line[2..].trim();
-
-            match key {
-                "P" => name = val.to_string(),
-                "V" => version = val.to_string(),
-                "T" => description = val.to_string(),
-                "I" => installed_size = val.parse().unwrap_or(0),
-                "D" => {
-                    for dep in val.split_whitespace() {
-                        let dname = super::parse_dep_name(dep);
-                        if !dname.is_empty() && !dname.starts_with('!') {
-                            depends.push(dname.to_string());
-                        }
-                    }
-                }
-                "p" => {
-                    for prov in val.split_whitespace() {
-                        let pname = super::parse_dep_name(prov);
-                        if !pname.is_empty() {
-                            provides.push(pname.to_string());
-                        }
-                    }
-                }
-                _ => {}
-            }
+        if let Some(pkg) = parse_apk_stanza(stanza, mirror, branch, repo, arch) {
+            packages.push(pkg);
         }
-
-        if name.is_empty() || version.is_empty() {
-            continue;
-        }
-
-        let url = format!("{mirror}/{branch}/{repo}/{arch}/{name}-{version}.apk");
-        packages.push(PackageMetadata {
-            name,
-            version,
-            description,
-            download_url: url,
-            sha256: None,
-            installed_size,
-            depends,
-            provides,
-        });
     }
 
     packages


### PR DESCRIPTION
🎯 **What:** Extracted the inner stanza parsing logic in `parse_apkindex` into a separate `parse_apk_stanza` function.
💡 **Why:** Reduces nesting, makes the code much easier to read and maintain, and adheres to single responsibility principle.
✅ **Verification:** Passed all `cargo test --bin oil` and `cargo clippy/fmt` checks.
✨ **Result:** Simplified `parse_apkindex` and isolated package parsing logic.

---
*PR created automatically by Jules for task [11407467622099729642](https://jules.google.com/task/11407467622099729642) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor and formatting in registry parsing and CLI output paths; no new logic or API changes.
> 
> **Overview**
> **APK index parsing** is refactored by pulling per-stanza field parsing out of `parse_apkindex` into a new `parse_apk_stanza` helper that returns `Option<PackageMetadata>`. `parse_apkindex` now only splits stanzas and collects successful parses, with the same validation rules (skip empty name/version) as before.
> 
> **`main.rs`** gets minor cleanup only: `pub mod util` is moved below the `#[cfg]` modules, and a few `eprintln!` / `println!` / `ChecksumMismatch` call sites are reformatted—no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c1cbdba5ae478bf2d4b2cbc82abe886c9d03d7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->