### PR TITLE
🔒 Fix unsafe permissions on /run/user/0 by adding explicit chown for root

### DIFF
--- a/scripts/lib/assemble-rootfs.sh
+++ b/scripts/lib/assemble-rootfs.sh
@@ -131,6 +131,7 @@ fi
 /bin/toybox mount -t tmpfs -o "$SHM_SIZE" tmpfs /dev/shm
 /bin/toybox mount -t tmpfs -o mode=1777 tmpfs /tmp
 /bin/toybox mkdir -p /run/user/0
+/bin/toybox chown 0:0 /run/user/0
 /bin/toybox chmod 700 /run/user/0
 /bin/toybox mkdir -p /state
 # Try to mount state partition (if available)

--- a/system/backends/appliance/initramfs/init
+++ b/system/backends/appliance/initramfs/init
@@ -24,6 +24,8 @@ fi
 mount -t tmpfs -o "$SHM_SIZE" tmpfs /dev/shm
 mount -t tmpfs -o mode=1777 tmpfs /tmp
 mkdir -p /run/user/0 /tmp /mnt/root
+chown 0:0 /run/user/0 2>/dev/null || true
+chmod 700 /run/user/0 2>/dev/null || true
 
 # Parse kernel cmdline
 ALPENGLOW_IMAGE=""

--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -34,6 +34,9 @@ fn main() {
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
+    if let Err(e) = std::os::unix::fs::chown("/run/user/0", Some(0), Some(0)) {
+        eprintln!("init: failed to chown /run/user/0: {}", e);
+    }
     if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }


### PR DESCRIPTION
🎯 **What:** The /run/user/0 directory was created and had its permissions set, but did not have its owner explicitly set.
⚠️ **Risk:** The directory might be owned by an unprivileged user if created within an unexpected context, or it might inherit an unexpected group owner. This directory typically stores user-specific runtime files (like sockets) and should be strictly owned by root.
🛡️ **Solution:** Added an explicit call to `std::os::unix::fs::chown("/run/user/0", Some(0), Some(0))` before setting permissions to `0o700`. This ensures it is strictly owned by root (uid 0, gid 0).

---
*PR created automatically by Jules for task [4277297421091061821](https://jules.google.com/task/4277297421091061821) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, early-boot directory ownership fix with no changes to auth, networking, or state handling.
> 
> **Overview**
> **Hardens `/run/user/0` setup** so the runtime directory is owned by root before permissions are locked down to `700`.
> 
> The change is applied consistently across the **embedded toybox init** in `assemble-rootfs.sh`, the **appliance initramfs** shell `init` (with `chown`/`chmod` guarded by `2>/dev/null || true`), and the **Rust init** (`init.rs`) via `chown(..., Some(0), Some(0))` ahead of the existing `0o700` `set_permissions` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460cef8eae52c0ab30ffa4e45af0b469d095b2f2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->