### PR TITLE
🔒 Fix unsafe shell fallback on init failure

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -54,7 +54,7 @@ fn main() {
         .env_clear()
         .exec();
     eprintln!("init: dinit exec failed: {}", err);
-    let _ = Command::new("/usr/bin/sh").env_clear().exec();
+    std::process::exit(1);
 }
 fn run(prog: &str, args: &[&str]) {
     if let Err(e) = Command::new(prog).args(args).env_clear().status() {


### PR DESCRIPTION
🎯 **What:** Removed the fallback to a root shell (`/usr/bin/sh`) when `dinit` fails to execute in the Rust init implementation.
⚠️ **Risk:** Failing open to a root shell on init failure allows unauthorized root access if an attacker can cause the init process to fail, undermining secure boot mechanisms.
🛡️ **Solution:** Replaced the shell fallback with `std::process::exit(1)`, which will safely trigger a kernel panic and halt the system without providing unauthorized access.

---
*PR created automatically by Jules for task [14468895915783741146](https://jules.google.com/task/14468895915783741146) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavior change on an already-failing boot path; reduces attack surface by removing an interactive root shell fallback.
> 
> **Overview**
> **Hardens boot failure handling** in the appliance `initramfs` Rust init (`init.rs`): if `/usr/sbin/dinit` cannot be `exec`'d, the process no longer drops into a root `/usr/bin/sh` fallback.
> 
> Instead it logs the error and calls **`std::process::exit(1)`**, so a broken init path does not leave an interactive root shell on the console.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5971492c571862080dae029a0051678d9bc97e32. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->