### PR TITLE
🔒 Pin Docker base image to specific digest to prevent supply chain attacks

### DIFF
--- a/scripts/build-aarch64-fast.sh
+++ b/scripts/build-aarch64-fast.sh
@@ -29,7 +29,7 @@ DINIT_BIN="${BUILD_OUT}/dinit-aarch64"
 LD_MUSL="${BUILD_OUT}/ld-musl-aarch64.so.1"
 if [ ! -f "${DINIT_BIN}" ] || [ ! -f "${LD_MUSL}" ]; then
   echo "→ Building dinit ${DINIT_VERSION} for aarch64..."
-  docker run --rm --platform linux/arm64 -v "${BUILD_OUT}:/out" alpine:3.21 sh -c "
+  docker run --rm --platform linux/arm64 -v "${BUILD_OUT}:/out" alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d sh -c "
     apk add --no-cache g++ make linux-headers git >/dev/null
     cd /tmp
     git clone --depth 1 --branch v${DINIT_VERSION} https://github.com/davmac314/dinit.git >/dev/null 2>&1


### PR DESCRIPTION
🎯 **What:** Pinned the `alpine:3.21` base image in `scripts/build-aarch64-fast.sh` to its specific SHA256 digest (`sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d`).
⚠️ **Risk:** Pulling via a mutable tag like `3.21` leaves the build process vulnerable to a supply chain attack. If an attacker compromises the image repository, they could push a malicious image to that tag, which would then be executed during the build process.
🛡️ **Solution:** Using a specific digest ensures that the exact image content is validated cryptographically upon download. The image cannot be altered without changing its digest, eliminating this attack vector.

---
*PR created automatically by Jules for task [13509290932708862030](https://jules.google.com/task/13509290932708862030) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line build-script hardening with no runtime or auth changes; only affects which Alpine image is pulled for the dinit cross-build step.
> 
> **Overview**
> Pins the **arm64 Alpine** image used in `scripts/build-aarch64-fast.sh` when building **dinit** inside Docker from the mutable tag `alpine:3.21` to **`alpine:3.21@sha256:48b0309…`**, so pulls resolve to a fixed image content instead of whatever currently points at that tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80e17c766b3c8f124c08450c685805087998a46c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->