### PR TITLE
🔒 Fix eval interpolation vulnerability in zig wrappers

### DIFF
--- a/scripts/aarch64-linux-musl-zigcc
+++ b/scripts/aarch64-linux-musl-zigcc
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
-    --target=aarch64-unknown-linux-musl) args="$args -target aarch64-linux-musl" ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    --target=aarch64-unknown-linux-musl) set -- "$@" "-target" "aarch64-linux-musl" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig cc $args
+exec zig cc "$@"

--- a/scripts/aarch64-linux-musl-zigcxx
+++ b/scripts/aarch64-linux-musl-zigcxx
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
     --target=aarch64-unknown-linux-musl) ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig c++ -target aarch64-linux-musl $args
+exec zig c++ -target aarch64-linux-musl "$@"

--- a/scripts/x86_64-linux-musl-zigcc
+++ b/scripts/x86_64-linux-musl-zigcc
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
-    --target=x86_64-unknown-linux-musl) args="$args -target x86_64-linux-musl" ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    --target=x86_64-unknown-linux-musl) set -- "$@" "-target" "x86_64-linux-musl" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig cc $args
+exec zig cc "$@"

--- a/scripts/x86_64-linux-musl-zigcxx
+++ b/scripts/x86_64-linux-musl-zigcxx
@@ -1,9 +1,9 @@
 #!/bin/sh
-args=""
-for arg in "$@"; do
+for arg do
+  shift
   case "$arg" in
     --target=x86_64-unknown-linux-musl) ;;
-    *) args="$args $(printf '%s' "$arg" | sed "s/'/'\\\\''/g; s/.*/'&'/")" ;;
+    *) set -- "$@" "$arg" ;;
   esac
 done
-eval exec zig c++ -target x86_64-linux-musl $args
+exec zig c++ -target x86_64-linux-musl "$@"


### PR DESCRIPTION
🎯 **What:** Removed unsafe use of shell interpolation in `eval` in zig wrapper scripts. 
⚠️ **Risk:** Shell scripts were vulnerable to `eval` injection when inputs weren't properly quoted, potentially leading to arbitrary code execution if user-controlled input was passed to the wrapper scripts. 
🛡️ **Solution:** Replaced string concatenation and `eval` with direct positional argument manipulation (`set --`) and `exec zig ... "$@"` to ensure arguments are passed safely without risk of shell expansion or code execution.

---
*PR created automatically by Jules for task [2164068326669851046](https://jules.google.com/task/2164068326669851046) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized shell changes that reduce injection risk; main residual risk is a regression in cross-compile builds if argument rewriting mishandles edge-case flags.
> 
> **Overview**
> **Security fix** for the aarch64 and x86_64 **musl Zig compiler wrapper scripts** (`*-zigcc` and `*-zigcxx`). They no longer build a single command string with `sed` quoting and run it through **`eval exec zig …`**.
> 
> Each wrapper now walks arguments with **`for arg do` / `shift`**, maps `--target=…-unknown-linux-musl` to Zig’s `-target` form where needed (C wrappers only; C++ wrappers still drop the Rust-style target flag and pass a fixed `-target`), and **`exec`s Zig with `"$@"`** so argv is passed without shell re-parsing.
> 
> This closes a path where malformed or attacker-influenced compiler flags could break out of quoting and execute arbitrary shell code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c11d5764ff2084867c58d81341093c813e29ab14. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->