### PR TITLE
🔒 Fix insecure file permissions for /state directory

### DIFF
--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -105,9 +105,13 @@ pub fn main() void {
 
     mkdir("/run/user", 0o755);
     mkdir("/run/user/0", 0o700);
-    mkdir("/state", 0o755);
+<<<<<<< HEAD
+    mkdir("/state", 0o700);
     mkdir("/tmp", 0o1777);
     mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
+=======
+    mkdir("/state", 0o700);
+>>>>>>> e915720 (🔒 Fix insecure file permissions for /state directory)
 
     write_console("\nAlpenglow boot\n\n");
 


### PR DESCRIPTION
🎯 **What:** The /state directory is created with 0755 permissions which is too permissive.
⚠️ **Risk:** Any user on the system could read the contents of the /state directory, exposing potentially sensitive internal data.
🛡️ **Solution:** Changed the permissions of the /state directory to 0700 so that only the root user can access it, ensuring better security for state persistence.

---
*PR created automatically by Jules for task [9133186658589246823](https://jules.google.com/task/9133186658589246823) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Boot-time init changes affect filesystem layout at every boot; unresolved conflict markers would break the build, and dropping the `/tmp` tmpfs mount by mistake would be a functional regression.
> 
> **Overview**
> **Tightens permissions** on the boot-time `/state` mountpoint: `mkdir("/state", …)` changes from `0o755` to `0o700` so only root can access the directory before persistent state is mounted (aligned with `/state` as the appliance state root).
> 
> **Merge conflict left in `init.zig`:** the hunk still contains `<<<<<<<` / `=======` / `>>>>>>>` markers. The **HEAD** side also keeps `mkdir("/tmp", …)` and the `tmpfs` mount for `/tmp`; the other side only repeats the `/state` line. That must be resolved so the file builds and `/tmp` behavior is intentional.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb75baeb8e709a59142b657e11a9d9ef8512aa6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->