### PR TITLE
🔒 Fix raw curl/wget download vulnerability in build-v86-kernel.sh

### DIFF
--- a/scripts/build-v86-kernel.sh
+++ b/scripts/build-v86-kernel.sh
@@ -8,6 +8,7 @@ KERNEL_OUT="${ROOT_DIR}/site/public/v86/alpenglow-v86-vmlinuz"
 BACKEND="${ROOT_DIR}/system/backends/appliance"
 KERNEL_VERSION="${KERNEL_VERSION:-$(grep -E '^KERNEL_VERSION="\$\{KERNEL_VERSION:-' "${ROOT_DIR}/scripts/boot-native.sh" | sed -n 's/.*KERNEL_VERSION:-\([0-9.]*\).*/\1/p')}"
 KERNEL_TAR="linux-${KERNEL_VERSION}"
+KERNEL_ORG_SIGN_KEY="B8868C80BA62A1FFFAF5FDA9632D3A06589DA6B1"
 STAMP="${BUILD_DIR}/.kernel-v86-i686-${KERNEL_VERSION}.ok"
 V86_KERNEL_JOBS="${V86_KERNEL_JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 2)}"
 
@@ -39,9 +40,18 @@ build_in_tree() {
 }
 
 fetch_kernel() {
-if [ ! -d "${BUILD_DIR}/${KERNEL_TAR}" ]; then
+  if [ ! -d "${BUILD_DIR}/${KERNEL_TAR}" ]; then
     curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/${KERNEL_TAR}.tar.xz" -o "${BUILD_DIR}/${KERNEL_TAR}.tar.xz"
-    curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc" | grep " ${KERNEL_TAR}\.tar\.xz\$" | (cd "${BUILD_DIR}" && sha256sum -c -)
+    curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc" -o "${BUILD_DIR}/sha256sums.asc"
+
+    # Verify the signed checksum manifest against the kernel.org checksum autosigner key.
+    rm -f "${BUILD_DIR}/kernel-autosigner.gpg"
+    curl -fsSL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${KERNEL_ORG_SIGN_KEY}" -o "${BUILD_DIR}/kernel-autosigner.asc"
+    gpg --no-default-keyring --keyring "${BUILD_DIR}/kernel-autosigner.gpg" --batch --yes --import "${BUILD_DIR}/kernel-autosigner.asc" >/dev/null 2>&1
+    gpg --no-default-keyring --keyring "${BUILD_DIR}/kernel-autosigner.gpg" --with-colons --list-keys 2>/dev/null | grep -q "^fpr.*:${KERNEL_ORG_SIGN_KEY}:"
+    gpgv --keyring "${BUILD_DIR}/kernel-autosigner.gpg" "${BUILD_DIR}/sha256sums.asc"
+
+    grep " ${KERNEL_TAR}\.tar\.xz\$" "${BUILD_DIR}/sha256sums.asc" | (cd "${BUILD_DIR}" && sha256sum -c -)
     tar -xf "${BUILD_DIR}/${KERNEL_TAR}.tar.xz" -C "${BUILD_DIR}"
   fi
 }
@@ -73,11 +83,18 @@ docker run --rm --platform linux/amd64 \
     apt-get update -qq
     apt-get install -y -qq build-essential bc bison flex libssl-dev libelf-dev \
       libncurses-dev dwarves rsync kmod wget xz-utils zstd ca-certificates \
-      gcc-i686-linux-gnu >/dev/null
+      gcc-i686-linux-gnu gnupg >/dev/null
     cd /out
     if [ ! -d "'"${KERNEL_TAR}"'" ]; then
       wget -q "https://cdn.kernel.org/pub/linux/kernel/v7.x/'"${KERNEL_TAR}"'.tar.xz" -O '"${KERNEL_TAR}"'.tar.xz
       wget -q "https://cdn.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc" -O sha256sums.asc
+
+      rm -f kernel-autosigner.gpg
+      wget -q "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x'"${KERNEL_ORG_SIGN_KEY}"'" -O kernel-autosigner.asc
+      gpg --no-default-keyring --keyring kernel-autosigner.gpg --batch --yes --import kernel-autosigner.asc >/dev/null 2>&1
+      gpg --no-default-keyring --keyring kernel-autosigner.gpg --with-colons --list-keys 2>/dev/null | grep -q "^fpr.*:'"${KERNEL_ORG_SIGN_KEY}"':"
+      gpgv --keyring kernel-autosigner.gpg sha256sums.asc
+
       grep " '"${KERNEL_TAR}"'\.tar\.xz\$" sha256sums.asc | sha256sum -c -
       tar -xf '"${KERNEL_TAR}"'.tar.xz
     fi

--- a/scripts/build-v86-kernel.sh
+++ b/scripts/build-v86-kernel.sh
@@ -41,6 +41,7 @@ build_in_tree() {
 fetch_kernel() {
 if [ ! -d "${BUILD_DIR}/${KERNEL_TAR}" ]; then
     curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/${KERNEL_TAR}.tar.xz" -o "${BUILD_DIR}/${KERNEL_TAR}.tar.xz"
+    curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc" | grep " ${KERNEL_TAR}\.tar\.xz\$" | (cd "${BUILD_DIR}" && sha256sum -c -)
     tar -xf "${BUILD_DIR}/${KERNEL_TAR}.tar.xz" -C "${BUILD_DIR}"
   fi
 }
@@ -76,6 +77,8 @@ docker run --rm --platform linux/amd64 \
     cd /out
     if [ ! -d "'"${KERNEL_TAR}"'" ]; then
       wget -q "https://cdn.kernel.org/pub/linux/kernel/v7.x/'"${KERNEL_TAR}"'.tar.xz" -O '"${KERNEL_TAR}"'.tar.xz
+      wget -q "https://cdn.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc" -O sha256sums.asc
+      grep " '"${KERNEL_TAR}"'\.tar\.xz\$" sha256sums.asc | sha256sum -c -
       tar -xf '"${KERNEL_TAR}"'.tar.xz
     fi
     cd "'"${KERNEL_TAR}"'"


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the lack of checksum verification when downloading the kernel source using curl/wget.
⚠️ **Risk:** The potential impact is that an attacker who compromises the kernel.org CDN or performs a Man-in-the-Middle attack could inject a malicious kernel tarball, which would then be executed during the build process.
🛡️ **Solution:** The fix adds a step to download the `sha256sums.asc` file from kernel.org and uses `sha256sum -c` to cryptographically verify the downloaded tarball before extraction.

---
*PR created automatically by Jules for task [6102330230093529099](https://jules.google.com/task/6102330230093529099) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Supply-chain hardening in a build-only script; no runtime or auth changes, with possible build failures if GPG/keyserver access is unavailable.
> 
> **Overview**
> **`scripts/build-v86-kernel.sh`** no longer extracts the Linux kernel source immediately after `curl`/`wget`. Both the native **`fetch_kernel`** path and the Debian Docker fallback now download **`sha256sums.asc`**, import the pinned kernel.org checksum autosigner key (**`KERNEL_ORG_SIGN_KEY`**), validate the key fingerprint, **`gpgv`** the manifest, and run **`sha256sum -c`** on the matching **`linux-*.tar.xz`** before **`tar`**.
> 
> The Docker image install list adds **`gnupg`** so the same checks run inside the container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d2c273f04491c2782abaa896a3118aa790950da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->