### PR TITLE
🧪 [zig] Add unit test for sysOpen function

### DIFF
--- a/system/alpenglow-ctl/build.zig
+++ b/system/alpenglow-ctl/build.zig
@@ -83,6 +83,18 @@ pub fn build(b: *std.Build) void {
     kernel_tests.root_module.link_libc = true;
     const run_kernel_tests = b.addRunArtifact(kernel_tests);
 
+    const common_test_mod = b.createModule(.{
+        .root_source_file = b.path("../zig-common.zig"),
+        .target = b.graph.host,
+        .optimize = optimize,
+    });
+    const common_tests = b.addTest(.{
+        .root_module = common_test_mod,
+    });
+    common_tests.root_module.link_libc = true;
+    const run_common_tests = b.addRunArtifact(common_tests);
+
     const test_step = b.step("test", "Run alpenglow-ctl tests");
     test_step.dependOn(&run_kernel_tests.step);
+    test_step.dependOn(&run_common_tests.step);
 }

--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -315,13 +315,20 @@ test "checkSyscall errors" {
 }
 
 test "sysOpen" {
+    if (builtin.os.tag != .linux) return;
     const testing = std.testing;
     const fd = try sysOpen("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
     try testing.expect(fd >= 0);
     sysClose(fd);
 
-    // Test open a non-existent file
-    try testing.expectError(error.FileNotFound, sysOpen("/tmp/does_not_exist_ever_random_blabla", .{ .ACCMODE = .RDONLY }, 0));
+    // Test open a non-existent file inside an isolated temp directory.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const missing_path = try std.fs.path.join(testing.allocator, &[_][]const u8{ ".zig-cache", "tmp", &tmp.sub_path, "missing" });
+    defer testing.allocator.free(missing_path);
+    var buf: [4096]u8 = undefined;
+    const path_z = pathToZ(missing_path, &buf) orelse return error.NameTooLong;
+    try testing.expectError(error.FileNotFound, sysOpen(path_z, .{ .ACCMODE = .RDONLY }, 0));
 }
 
 test "MyArrayList.appendSlice" {

--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -314,6 +314,16 @@ test "checkSyscall errors" {
     try testing.expectError(error.Unexpected, checkSyscall(eperm_rc));
 }
 
+test "sysOpen" {
+    const testing = std.testing;
+    const fd = try sysOpen("/dev/null", .{ .ACCMODE = .RDONLY }, 0);
+    try testing.expect(fd >= 0);
+    sysClose(fd);
+
+    // Test open a non-existent file
+    try testing.expectError(error.FileNotFound, sysOpen("/tmp/does_not_exist_ever_random_blabla", .{ .ACCMODE = .RDONLY }, 0));
+}
+
 test "MyArrayList.appendSlice" {
     const allocator = std.testing.allocator;
     var list = MyArrayList(u8).init(allocator);


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for sysOpen handling platform-specific errors and basic file opening.
📊 **Coverage:** Happy path opening /dev/null and error condition for FileNotFound.
✨ **Result:** Improved test coverage for syscall wrappers.

---
*PR created automatically by Jules for task [13327124715673417778](https://jules.google.com/task/13327124715673417778) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to syscall wrapper coverage and build wiring; no production behavior changes.
> 
> **Overview**
> Adds **Linux-only** coverage for the shared `sysOpen` wrapper in `zig-common.zig`: a successful read-only open of `/dev/null`, then an expected `error.FileNotFound` for a path under an isolated `testing.tmpDir`.
> 
> The **alpenglow-ctl** `test` build step now also runs tests rooted at `zig-common.zig` (with libc linked), so those common helpers—including the new `sysOpen` test—execute alongside the existing kernel tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897b77ed45da11916eff7eeeecc0433338bc8fd2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->