### PR TITLE
🧪 [testing improvement] Add getErrno mapping tests

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -290,6 +290,29 @@ test "pathToZ" {
     try testing.expect(large_z == null);
 }
 
+test "getErrno" {
+    const testing = std.testing;
+
+    // Test zero (SUCCESS)
+    try testing.expectEqual(std.os.linux.E.SUCCESS, getErrno(0));
+
+    // Test positive values (SUCCESS)
+    try testing.expectEqual(std.os.linux.E.SUCCESS, getErrno(1));
+    try testing.expectEqual(std.os.linux.E.SUCCESS, getErrno(4096));
+    try testing.expectEqual(std.os.linux.E.SUCCESS, getErrno(8192));
+
+    // Test negative values corresponding to valid error codes
+    const enoent_rc: usize = @bitCast(-@as(isize, @intFromEnum(std.os.linux.E.NOENT)));
+    try testing.expectEqual(std.os.linux.E.NOENT, getErrno(enoent_rc));
+
+    // Test boundaries
+    const bound1: usize = @bitCast(@as(isize, -4096)); // <= -4096 is not a valid errno, returns SUCCESS
+    try testing.expectEqual(std.os.linux.E.SUCCESS, getErrno(bound1));
+
+    const bound2: usize = @bitCast(@as(isize, -4095)); // > -4096 is valid errno
+    try testing.expectEqual(@as(std.os.linux.E, @enumFromInt(4095)), getErrno(bound2));
+}
+
 test "checkSyscall success" {
     // 0 is SUCCESS
     try checkSyscall(0);


### PR DESCRIPTION
🎯 **What:** The testing gap for `getErrno` mapping for positive values and boundaries has been addressed.
📊 **Coverage:** Scenarios now tested include zero values, positive values, specific negative error values (like NOENT), and boundary conditions (-4096 and -4095).
✨ **Result:** Improved test coverage and reliability for `getErrno` error mapping logic.

---
*PR created automatically by Jules for task [2696585205750978185](https://jules.google.com/task/2696585205750978185) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic modified; low risk aside from CI test runtime.
> 
> **Overview**
> Adds a dedicated **`test "getErrno"`** block in `system/zig-common.zig` to exercise syscall return-to-errno mapping that was only covered indirectly via `checkSyscall` tests.
> 
> The new cases assert **zero and positive** return codes map to `SUCCESS`, a **bit-cast negative `ENOENT`** maps correctly, and the **-4096 / -4095** boundary behavior matches the implementation (values at or below -4096 are treated as non-errno success; -4095 decodes to errno 4095).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17eecad66707cef8dcc9de861e55aff005d27ecf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->