### PR TITLE
🔒 Fix unsafe fallback behavior in init by rebooting on exec failure

### DIFF
--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -44,7 +44,14 @@ fn exec_dinit() noreturn {
     };
     const envp = [_:null]?[*:0]const u8{null};
     _ = std.os.linux.syscall3(.execve, @intFromPtr(argv[0].?), @intFromPtr(&argv), @intFromPtr(&envp));
-    // If exec fails, panic/hang.
+    // If exec fails, reboot instead of hanging.
+    _ = std.os.linux.syscall4(
+        .reboot,
+        0xfee1dead, // LINUX_REBOOT_MAGIC1
+        672274793,  // LINUX_REBOOT_MAGIC2
+        0x01234567, // LINUX_REBOOT_CMD_RESTART
+        0,
+    );
     while (true) {}
 }
 


### PR DESCRIPTION
🎯 **What:** Fixed an issue in `init.zig` where failure to `exec` the primary init process (`dinit`) would cause the system to hang indefinitely in an infinite loop. The code now correctly invokes the kernel `reboot` syscall when `execve` fails.
⚠️ **Risk:** An infinite loop in PID 1 means the system becomes unresponsive and unrecoverable without external power cycling if initialization fails. This is a denial of service risk, especially in automated or remote deployments where manual intervention is difficult.
🛡️ **Solution:** Replaced the infinite loop with a direct `reboot` syscall using the standard Linux magic values (passed as raw hex/integer values to avoid stdlib compatibility issues across Zig versions) and the `RESTART` command. This ensures the system attempts to recover or cycle properly instead of becoming completely frozen in an undefined state.

---
*PR created automatically by Jules for task [16643056514813311207](https://jules.google.com/task/16643056514813311207) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PID 1 failure handling in the boot path; mis-invocation could reboot unexpectedly, but it only runs after `execve` already failed.
> 
> **Overview**
> When PID 1 fails to `execve` `/sbin/dinit`, **`exec_dinit`** now issues a Linux **`reboot`** syscall with `LINUX_REBOOT_CMD_RESTART` (magic constants inlined as literals) before the existing infinite loop.
> 
> That replaces a comment-only “panic/hang” path so a broken early init does not leave the machine stuck in an unrecoverable busy loop without cycling hardware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b407040bf83d444ff27b424fb7e50795edcb028. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->