### PR TITLE
🧪 [testing improvement] Add sysRead test

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -362,7 +362,6 @@ test "fileExists" {
 test "sysRead" {
     if (builtin.os.tag != .linux) return;
     const testing = std.testing;
-
     // Use an isolated temporary file for the test.
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -358,3 +358,34 @@ test "fileExists" {
     // A non-existent file should not exist
     try testing.expect(!fileExists("../nonexistent-file-for-test.zig"));
 }
+
+test "sysRead" {
+    if (builtin.os.tag != .linux) return;
+    const testing = std.testing;
+
+    // Use an isolated temporary file for the test.
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const test_file_path = try std.fs.path.join(testing.allocator, &[_][]const u8{ ".zig-cache", "tmp", &tmp.sub_path, "testfile" });
+    defer testing.allocator.free(test_file_path);
+
+    // Write some data to a file
+    const test_data = "Hello sysRead test";
+    try writeFile(test_file_path, test_data, true);
+
+    // Open file to read using sysOpen
+    var buf_path: [4096]u8 = undefined;
+    const path_z = pathToZ(test_file_path, &buf_path) orelse return error.NameTooLong;
+    const fd = try sysOpen(path_z, .{ .CLOEXEC = true }, 0);
+    defer sysClose(fd);
+
+    // Read the data back
+    var read_buf: [32]u8 = undefined;
+    const bytes_read = try sysRead(fd, &read_buf);
+
+    try testing.expectEqual(test_data.len, bytes_read);
+    try testing.expectEqualStrings(test_data, read_buf[0..bytes_read]);
+
+    // Test reading from an invalid fd fails
+    try testing.expectError(error.Unexpected, sysRead(-1, &read_buf));
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for sysRead was addressed.
📊 **Coverage:** Happy path reading data from a valid fd and error handling for reading from an invalid fd (-1) are now tested.
✨ **Result:** The system test coverage has increased and ensures sysRead accurately reads bytes and handles unexpected errors correctly.

---
*PR created automatically by Jules for task [11665014905746049765](https://jules.google.com/task/11665014905746049765) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production code paths are modified.
> 
> **Overview**
> Adds a **Linux-only** `test "sysRead"` in `zig-common.zig` that exercises the syscall wrapper without changing runtime behavior.
> 
> The test writes known bytes to a temp file, opens it with `sysOpen`, reads via `sysRead`, and asserts length and content match. It also expects `error.Unexpected` when reading from fd `-1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fbd7dd5e88db6dd2f510fcc19713ea34b84c885. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->