### PR TITLE
🧪 [Testing] Add unit tests for sysWrite in zig-common

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -388,3 +388,40 @@ test "sysRead" {
     // Test reading from an invalid fd fails
     try testing.expectError(error.Unexpected, sysRead(-1, &read_buf));
 }
+
+test "sysWrite" {
+    if (builtin.os.tag != .linux) return;
+    const testing = std.testing;
+
+    var pipe_fds: [2]i32 = undefined;
+    const rc = linux.pipe(&pipe_fds);
+    try testing.expectEqual(@as(usize, 0), rc);
+
+    const read_fd = pipe_fds[0];
+    const write_fd = pipe_fds[1];
+
+    defer sysClose(read_fd);
+    defer sysClose(write_fd);
+
+    // Test writing an empty slice
+    try sysWrite(write_fd, "");
+
+    // Test writing some data
+    const data = "hello world";
+    try sysWrite(write_fd, data);
+
+    var buf: [16]u8 = undefined;
+    const n = try sysRead(read_fd, &buf);
+
+    try testing.expectEqualStrings(data, buf[0..n]);
+}
+
+test "sysWrite errors" {
+    if (builtin.os.tag != .linux) return;
+    const testing = std.testing;
+
+    // Write to an invalid file descriptor
+    const invalid_fd: i32 = -1;
+
+    try testing.expectError(error.Unexpected, sysWrite(invalid_fd, "test"));
+}


### PR DESCRIPTION
🎯 **What:** The `sysWrite` function in `system/zig-common.zig` was previously untested. This PR adds unit tests for it.
📊 **Coverage:** Added tests to cover the happy path (writing valid data to a pipe), an edge case (writing an empty slice), and an error condition (writing to an invalid file descriptor which should return an error).
✨ **Result:** Test coverage for syscall wrappers is improved, making refactoring safer.

---
*PR created automatically by Jules for task [6162557019421416451](https://jules.google.com/task/6162557019421416451) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds **unit test coverage** for the `sysWrite` syscall wrapper in `system/zig-common.zig`; production code is unchanged.
> 
> A **`sysWrite`** test uses a Linux pipe to assert an empty write succeeds and that `"hello world"` written on the write end is read back via `sysRead`. A separate **`sysWrite errors`** test expects `error.Unexpected` when writing to fd `-1`. Both tests no-op on non-Linux hosts, matching the existing `sysOpen` test pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5684be4aab8820dc5b9160ed5ae053216b806cbf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->