### PR TITLE
🧪 [testing] add tests for fileExists in zig-common

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -261,6 +261,16 @@ pub fn writeStderr(msg: []const u8) void {
     _ = linux.write(2, msg.ptr, msg.len);
 }
 
+test "fileExists" {
+    const testing = std.testing;
+
+    // Existing file
+    try testing.expect(fileExists("system/zig-common.zig") == true);
+
+    // Non-existing file
+    try testing.expect(fileExists("system/does-not-exist.txt") == false);
+}
+
 test "pathToZ" {
     const testing = std.testing;
     var buf: [16]u8 = undefined;


### PR DESCRIPTION
🎯 **What:** Added tests for the `fileExists` function in `system/zig-common.zig`.
📊 **Coverage:** Tests now verify an existing file (like the test file itself) and a non-existing file.
✨ **Result:** Improved test coverage and reliability for filesystem utility functions.

---
*PR created automatically by Jules for task [2775900251513238567](https://jules.google.com/task/2775900251513238567) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no modifications to `fileExists` or callers; minimal regression surface.
> 
> **Overview**
> Adds a **`test "fileExists"`** block in `system/zig-common.zig` alongside the existing `pathToZ` and syscall tests.
> 
> The new tests assert **`fileExists`** returns **true** for `system/zig-common.zig` and **false** for a missing path (`system/does-not-exist.txt`). **No production or API changes**—only test coverage for the shared filesystem helper used by tools like alpenglow-ctl zram setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a537df716a0bb7aa3b864c4da5f6cc068cd261b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->