### PR TITLE
Fix ICD JSON absolute path

### DIFF
--- a/system/backends/appliance/scripts/install-graphics-libs.sh
+++ b/system/backends/appliance/scripts/install-graphics-libs.sh
@@ -83,14 +83,14 @@ docker run --rm --platform linux/amd64 -e GRAPHICS_BACKEND="${GRAPHICS_BACKEND}"
     # Fix ICD json to use absolute path
     cp /usr/share/vulkan/icd.d/lvp_icd*.json /out/usr/share/vulkan/icd.d/lvp_icd.json 2>/dev/null || true
     if [ -f "/out/usr/share/vulkan/icd.d/lvp_icd.json" ]; then
-      sed -i "s#\"library_path\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" /out/usr/share/vulkan/icd.d/lvp_icd.json
+      sed -i -e "s#\"library_path\"[[:space:]]*:[[:space:]]*\"[^\"]*/\\([^/\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" -e "s#\"library_path\"[[:space:]]*:[[:space:]]*\"\\([^/\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" /out/usr/share/vulkan/icd.d/lvp_icd.json
     fi
   else
     cp /usr/share/vulkan/icd.d/*.json /out/usr/share/vulkan/icd.d/ 2>/dev/null || true
     rm -f /out/usr/share/vulkan/icd.d/lvp_icd*.json /out/usr/share/vulkan/icd.d/radeon_icd*.json
     for json in /out/usr/share/vulkan/icd.d/*.json; do
       [ -f "${json}" ] || continue
-      sed -i "s#\"library_path\"[[:space:]]*:[[:space:]]*\"\\([^\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" "${json}"
+      sed -i -e "s#\"library_path\"[[:space:]]*:[[:space:]]*\"[^\"]*/\\([^/\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" -e "s#\"library_path\"[[:space:]]*:[[:space:]]*\"\\([^/\"]*\\)\"#\"library_path\": \"/lib/x86_64-linux-gnu/\\1\"#" "${json}"
     done
   fi
 

--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -105,13 +105,9 @@ pub fn main() void {
 
     mkdir("/run/user", 0o755);
     mkdir("/run/user/0", 0o700);
-<<<<<<< HEAD
     mkdir("/state", 0o700);
     mkdir("/tmp", 0o1777);
     mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
-=======
-    mkdir("/state", 0o700);
->>>>>>> e915720 (🔒 Fix insecure file permissions for /state directory)
 
     write_console("\nAlpenglow boot\n\n");
 


### PR DESCRIPTION
Modifies the Vulkan ICD JSON to use absolute paths for the library_path correctly, stripping any preceding paths.

---
*PR created automatically by Jules for task [13841668274840774261](https://jules.google.com/task/13841668274840774261) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time packaging script only; affects how Vulkan ICD metadata is copied into the appliance image, with no auth or data handling impact.
> 
> **Overview**
> **Vulkan ICD JSON paths** in `install-graphics-libs.sh` are rewritten more reliably when glibc Mesa libs are staged for alpenglowed.
> 
> The previous `sed` prepended `/lib/x86_64-linux-gnu/` to the entire quoted `library_path` value. When Debian’s ICD files already include directory segments (e.g. `lib/x86_64-linux-gnu/...`), that produced invalid doubled paths. The script now uses two `sed -e` expressions: one that keeps only the final path component when slashes are present, and one that prefixes bare filenames—both targeting `/lib/x86_64-linux-gnu/<lib>`. The same logic applies to lavapipe (`lvp_icd.json`) in software mode and to each ICD JSON in the non-software loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dcae8347955d376c28d25f44fe16cf502380942. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->