### PR TITLE
🔒 Fix command injection vulnerability in init.rs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -3,9 +3,9 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 fn main() {
-    run("mount", &["-t", "proc", "proc", "/proc"]);
-    run("mount", &["-t", "sysfs", "sysfs", "/sys"]);
-    run("mount", &["-t", "devtmpfs", "devtmpfs", "/dev"]);
+    run("/bin/mount", &["-t", "proc", "proc", "/proc"]);
+    run("/bin/mount", &["-t", "sysfs", "sysfs", "/sys"]);
+    run("/bin/mount", &["-t", "devtmpfs", "devtmpfs", "/dev"]);
     for d in &["/run", "/dev/shm", "/tmp", "/state", "/sysroot"] {
         if let Err(e) = std::fs::create_dir_all(d) {
             eprintln!("init: failed to create directory {}: {}", d, e);
@@ -19,7 +19,7 @@ fn main() {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
     }
-    run("mount", &["-t", "tmpfs", "tmpfs", "/run"]);
+    run("/bin/mount", &["-t", "tmpfs", "tmpfs", "/run"]);
     let mut shm_size = String::from("mode=1777,size=256m");
     if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
         for line in meminfo.lines() {
@@ -34,11 +34,11 @@ fn main() {
         }
     }
     run(
-        "mount",
+        "/bin/mount",
         &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
     );
     run(
-        "mount",
+        "/bin/mount",
         &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
     );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a command injection via relative path execution in the run helper function.
⚠️ **Risk:** A local attacker could exploit this by modifying the PATH environment variable or placing a malicious executable with the same name in the current directory, resulting in arbitrary code execution with high privileges.
🛡️ **Solution:** The fix replaces the relative executable names ('mount', 'modprobe') with their absolute paths ('/bin/mount', '/sbin/modprobe'), mitigating the command injection vulnerability.

---
*PR created automatically by Jules for task [6537908463116696048](https://jules.google.com/task/6537908463116696048) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches PID 1 initramfs boot code where mistaken binary choice is high impact; the change is a small, targeted hardening with no new behavior beyond fixed executable paths.
> 
> **Overview**
> Hardens the Alpenglow **rust-init** (`init.rs`) by invoking **`/bin/mount`** and **`/sbin/modprobe`** instead of bare `mount` and `modprobe`, so early boot does not depend on PATH or cwd when spawning those helpers (same pattern already used for **`/usr/sbin/dinit`**). **`run`** still clears the environment before **`Command`**.
> 
> The rest of the diff is formatting only (multi-line **`mount`** calls, permission-mode branch, boot banner **`println!`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 265dd7ee499e3473ea9ef5ba7afb18399a10a6b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->