### PR TITLE
🧪 Add tests for renderJson in pressure.zig

### DIFF
--- a/system/alpenglow-ctl/build.zig
+++ b/system/alpenglow-ctl/build.zig
@@ -94,7 +94,21 @@ pub fn build(b: *std.Build) void {
     common_tests.root_module.link_libc = true;
     const run_common_tests = b.addRunArtifact(common_tests);
 
+    const pressure_test_mod = b.createModule(.{
+        .root_source_file = b.path("src/pressure.zig"),
+        .target = b.graph.host,
+        .optimize = optimize,
+    });
+    pressure_test_mod.addImport("common", common);
+
+    const pressure_tests = b.addTest(.{
+        .root_module = pressure_test_mod,
+    });
+    pressure_tests.root_module.link_libc = true;
+    const run_pressure_tests = b.addRunArtifact(pressure_tests);
+
     const test_step = b.step("test", "Run alpenglow-ctl tests");
     test_step.dependOn(&run_kernel_tests.step);
     test_step.dependOn(&run_common_tests.step);
+    test_step.dependOn(&run_pressure_tests.step);
 }

--- a/system/alpenglow-ctl/src/pressure.zig
+++ b/system/alpenglow-ctl/src/pressure.zig
@@ -104,3 +104,26 @@ pub fn run() !void {
         sleepSeconds(60);
     }
 }
+
+test "renderJson formats basic pressure values" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+    const p = Pressure{
+        .avg10 = 1.2345,
+        .avg60 = 2.0,
+        .avg300 = 0.56789,
+        .total = 123456,
+    };
+    const json = try renderJson(gpa, p);
+    defer gpa.free(json);
+    try testing.expectEqualStrings("{\"memory_some_avg10\":1.2345,\"memory_some_avg60\":2.0000,\"memory_some_avg300\":0.5679,\"memory_some_total\":123456}\n", json);
+}
+
+test "renderJson formats missing pressure values with zeros" {
+    const testing = std.testing;
+    const gpa = testing.allocator;
+    const p = Pressure{};
+    const json = try renderJson(gpa, p);
+    defer gpa.free(json);
+    try testing.expectEqualStrings("{\"memory_some_avg10\":0.0000,\"memory_some_avg60\":0.0000,\"memory_some_avg300\":0.0000,\"memory_some_total\":0}\n", json);
+}


### PR DESCRIPTION
🎯 **What:** Added missing unit tests for the pure function `renderJson` in `pressure.zig`.
📊 **Coverage:** Covered both a happy path with all values populated correctly checking 4-decimal float formats, and edge cases where data fields are missing (null).
✨ **Result:** Improved test coverage and regression protection for alpenglow-ctl.

---
*PR created automatically by Jules for task [2367762421514837111](https://jules.google.com/task/2367762421514837111) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and build wiring only; no changes to runtime pressurectl behavior.
> 
> **Overview**
> Adds **unit tests** for `renderJson` in `pressure.zig` and hooks them into the Zig **`test`** step.
> 
> `renderJson` is covered for a full `Pressure` struct (four-decimal floats and integer total) and for default/missing optional fields, which should serialize as **zeros**. **`build.zig`** now builds and runs tests from `src/pressure.zig` (with the `common` import), alongside existing kernel and common tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc057f3703e1dbb80b6282c2bb056ee691f31fa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->