### PR TITLE
🧪 add split_gzip_streams edge case tests

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -353,6 +353,68 @@ mod tests {
     }
 
     #[test]
+    fn test_split_gzip_streams_apk_size_exceeds_maximum() {
+        // Allocate a 2GB+1 byte vector initialized to zero.
+        // On modern Linux systems, this uses a lazy virtual memory allocation (mmap)
+        // and doesn't consume physical memory since we don't write to it.
+        let fake_large_data = vec![0u8; 2 * 1024 * 1024 * 1024 + 1];
+        let result = split_gzip_streams(&fake_large_data, 3);
+        assert!(result.is_err());
+        let err_msg = result.expect_err("Expected an error").to_string();
+        assert!(
+            err_msg.contains("exceeds maximum"),
+            "Unexpected error: {}",
+            err_msg
+        );
+    }
+
+    #[test]
+    fn test_split_gzip_streams_magic_byte_at_eof() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let mut data = create_gz_stream(b"stream 1")?;
+        data.extend(create_gz_stream(b"stream 2")?);
+        data.push(0x1f);
+
+        let result = split_gzip_streams(&data, 3);
+        assert!(result.is_err());
+        let err_msg = result.expect_err("Expected an error").to_string();
+        assert!(err_msg.contains("APK has 2 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_gzip_streams_only_magic_bytes() {
+        let mut data = vec![0x1f, 0x8b];
+        data.extend(vec![0x1f, 0x8b]);
+        data.extend(vec![0x1f, 0x8b]);
+
+        let result = split_gzip_streams(&data, 3);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_split_gzip_streams_extra_streams_ignored() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let stream1 = create_gz_stream(b"stream 1 data")?;
+        let stream2 = create_gz_stream(b"stream 2 data")?;
+        let stream3 = create_gz_stream(b"stream 3 data")?;
+        let stream4 = create_gz_stream(b"stream 4 data")?;
+
+        let mut combined = Vec::new();
+        combined.extend(&stream1);
+        combined.extend(&stream2);
+        combined.extend(&stream3);
+        combined.extend(&stream4);
+
+        let result = split_gzip_streams(&combined, 3);
+        assert!(result.is_ok());
+        let (out1, out2, out3) = result?;
+
+        assert_eq!(out1, b"stream 1 data");
+        assert_eq!(out2, b"stream 2 data");
+        assert_eq!(out3, b"stream 3 data");
+        Ok(())
+    }
+
+    #[test]
     fn test_split_gzip_streams_too_many_requested(
     ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream = create_gz_stream(b"data")?;


### PR DESCRIPTION
🎯 **What:** Missing tests for split_gzip_streams edge cases.
📊 **Coverage:** Added tests for APK size exceeding maximum, magic byte at EOF, only magic bytes without payload, and extra gzip streams being ignored.
✨ **Result:** Improved test coverage and reliability for gzip stream splitting edge cases.

---
*PR created automatically by Jules for task [17920281031952986443](https://jules.google.com/task/17920281031952986443) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior modifications.
> 
> **Overview**
> Adds **unit tests only** for `split_gzip_streams` in the Alpine APK extractor—no changes to production splitting or extraction logic.
> 
> New cases cover the **2GB total size cap** (lazy 2GB+1 byte buffer), **incomplete magic at EOF** (only two valid streams when three are required), **three gzip magic pairs with no real payloads**, and **concatenated APKs with a fourth gzip stream** (expects success using the first three streams only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58fa52b8710940ac6229eabb1f2f3d34642b5086. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->