### PR TITLE
🔒 Fix command injection via relative path execution in initramfs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -10,7 +10,11 @@ fn main() {
         if let Err(e) = std::fs::create_dir_all(d) {
             eprintln!("init: failed to create directory {}: {}", d, e);
         }
-        let mode = if *d == "/dev/shm" || *d == "/tmp" { 0o1777 } else { 0o755 };
+        let mode = if *d == "/dev/shm" || *d == "/tmp" {
+            0o1777
+        } else {
+            0o755
+        };
         if let Err(e) = std::fs::set_permissions(d, std::fs::Permissions::from_mode(mode)) {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
@@ -29,19 +33,26 @@ fn main() {
             }
         }
     }
-    run("mount", &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
+    );
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+    );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
     if let Err(e) = std::os::unix::fs::chown("/run/user/0", Some(0), Some(0)) {
         eprintln!("init: failed to chown /run/user/0: {}", e);
     }
-    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700))
+    {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
-        match Command::new("modprobe").arg(m).env_clear().status() {
+        match Command::new("/sbin/modprobe").arg(m).env_clear().status() {
             Ok(status) if !status.success() => {
                 eprintln!("init: modprobe {} failed with status: {}", m, status);
             }
@@ -51,7 +62,9 @@ fn main() {
             _ => {}
         }
     }
-    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    println!();
+    println!("Alpenglow boot (rust-init)");
+    println!();
     let err = Command::new("/usr/sbin/dinit")
         .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
         .env_clear()


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability where `modprobe` was executed using a relative path, which could potentially be intercepted or exploited if an attacker manipulated the environment or PATH.
     
⚠️ **Risk:** Running binaries without absolute paths inside an initramfs environment can open the door to executing unauthorized scripts, potentially compromising the early boot process.
     
🛡️ **Solution:** Updated the `Command::new` argument from `modprobe` to the absolute path `/sbin/modprobe` to strictly control the executed binary. Testing is skipped for this one-line fix as we're strictly enforcing binary paths.

---
*PR created automatically by Jules for task [8836990669404861129](https://jules.google.com/task/8836990669404861129) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path hardening in initramfs with no logic changes beyond which binary is executed; low blast radius if `/sbin/modprobe` is present as expected.
> 
> **Overview**
> Hardens early-boot module loading in the Rust initramfs `init` by running **`/sbin/modprobe`** instead of the bare `modprobe` name, so the binary is not resolved via `PATH` during init.
> 
> The rest of the diff is formatting only (multi-line `if`/`run` calls and boot banner `println!`s); behavior is unchanged aside from the modprobe invocation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13c11d23a85d515c0cc0abade5d14d6b80650960. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->