### PR TITLE
🧪 test(zig): add tests for envOrDefault

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -255,6 +255,22 @@ pub fn envOrDefault(key: []const u8, default: []const u8) []const u8 {
     return getenv(key) orelse default;
 }
 
+test "envOrDefault" {
+    const testing = std.testing;
+    const default_val = "fallback";
+
+    // Test fallback behavior
+    const res1 = envOrDefault("ZIG_TEST_VAR_NOT_SET_123", default_val);
+    try testing.expectEqualStrings(default_val, res1);
+
+    // Test with an environment variable we know exists (e.g., PATH)
+    const path = getenv("PATH");
+    if (path) |p| {
+        const res2 = envOrDefault("PATH", default_val);
+        try testing.expectEqualStrings(p, res2);
+    }
+}
+
 // Shared Zig helpers for alpenglow-ctl and legacy *-zig build shims.
 
 pub fn writeStderr(msg: []const u8) void {


### PR DESCRIPTION
🎯 **What:** The testing gap for `envOrDefault` in `system/zig-common.zig` has been addressed by adding a dedicated `test` block.
📊 **Coverage:** The new test covers:
- The fallback behavior when a queried environment variable is not present (returning the `default` string).
- The positive case when an environment variable (like `PATH`) is present and retrieved correctly.
✨ **Result:** Increased test coverage and validation of environment variable utilities in the Zig common library.

---
*PR created automatically by Jules for task [7543571987862184191](https://jules.google.com/task/7543571987862184191) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production logic or runtime behavior modifications.
> 
> **Overview**
> Adds a **`test "envOrDefault"`** block in `system/zig-common.zig` to exercise the helper that wraps `getenv` with a default string.
> 
> The test checks that a missing variable (`ZIG_TEST_VAR_NOT_SET_123`) returns the supplied default, and—when **`PATH`** is present in the environment—that `envOrDefault("PATH", …)` matches the value from `getenv("PATH")`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdbe5dee77ca1618290a5b633ebf5ad9177c132a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->