### PR TITLE
🧪 Add large input test for MyArrayList.appendSlice

### DIFF
--- a/system/zig-common.zig
+++ b/system/zig-common.zig
@@ -371,6 +371,14 @@ test "MyArrayList.appendSlice" {
     // Happy path: append again
     try list.appendSlice(&[_]u8{ 4, 5 });
     try std.testing.expectEqualSlices(u8, &[_]u8{ 1, 2, 3, 4, 5 }, list.items());
+
+    // Large input test to check dynamic memory expansion
+    var large_input: [5000]u8 = undefined;
+    @memset(&large_input, 42);
+    try list.appendSlice(&large_input);
+    try std.testing.expectEqual(5005, list.items().len);
+    try std.testing.expectEqual(42, list.items()[5]);
+    try std.testing.expectEqual(42, list.items()[5004]);
 }
 
 test "fileExists" {


### PR DESCRIPTION
🎯 **What:** Added missing large input test for `MyArrayList.appendSlice` to verify dynamic memory allocation expansion.
📊 **Coverage:** Now tests the dynamic reallocation path (expanding by 5000 elements at once) rather than just small unforced-expansion appends.
✨ **Result:** Increased test coverage for fundamental Zig components, ensuring memory safety during large copy operations.

---
*PR created automatically by Jules for task [1984041439687222808](https://jules.google.com/task/1984041439687222808) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 29133844f3138155efee5a12b7941f5ef9ea1d4b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->