### PR TITLE
🔒 Fix unauthenticated tap index fetch in TapRegistry

### DIFF
--- a/system/oil/src/tap.rs
+++ b/system/oil/src/tap.rs
@@ -111,6 +111,9 @@ impl TapRegistry {
     pub fn update(&self) -> Result<PackageIndex> {
         let cache_path = self.cache_path()?;
         let url = self.index_url();
+
+        crate::util::security::validate_download_url(&url)?;
+
         eprintln!("Fetching tap index: {url}");
         let resp = ureq::get(&url)
             .call()


### PR DESCRIPTION
🎯 **What:** Validated the URL of the tap index prior to fetching.
⚠️ **Risk:** Tap indexes could be fetched from unauthorized hosts, potentially leading to untrusted code execution or remote exploits if the downloaded JSON payload is maliciously crafted.
🛡️ **Solution:** Added a call to `crate::util::security::validate_download_url(&url)` to verify the target host of the tap before fetching.

---
*PR created automatically by Jules for task [8908534253273886058](https://jules.google.com/task/8908534253273886058) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d81583a86a7757a5de60f1e0c9cf73262d72a47e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->