### PR TITLE
🧹 refactor(initramfs): remove unused `PermissionsExt` import and use fully-qualified trait

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -1,5 +1,4 @@
 // Alpenglow Rust init — replaces the shell /init script
-use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
 fn main() {
@@ -10,8 +9,15 @@ fn main() {
         if let Err(e) = std::fs::create_dir_all(d) {
             eprintln!("init: failed to create directory {}: {}", d, e);
         }
-        let mode = if *d == "/dev/shm" || *d == "/tmp" { 0o1777 } else { 0o755 };
-        if let Err(e) = std::fs::set_permissions(d, std::fs::Permissions::from_mode(mode)) {
+        let mode = if *d == "/dev/shm" || *d == "/tmp" {
+            0o1777
+        } else {
+            0o755
+        };
+        if let Err(e) = std::fs::set_permissions(
+            d,
+            <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(mode),
+        ) {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
     }
@@ -29,15 +35,24 @@ fn main() {
             }
         }
     }
-    run("mount", &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
+    );
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+    );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
     if let Err(e) = std::os::unix::fs::chown("/run/user/0", Some(0), Some(0)) {
         eprintln!("init: failed to chown /run/user/0: {}", e);
     }
-    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+    if let Err(e) = std::fs::set_permissions(
+        "/run/user/0",
+        <std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(0o700),
+    ) {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
@@ -51,7 +66,9 @@ fn main() {
             _ => {}
         }
     }
-    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    println!();
+    println!("Alpenglow boot (rust-init)");
+    println!();
     let err = Command::new("/usr/sbin/dinit")
         .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
         .env_clear()


### PR DESCRIPTION
🎯 **What:** Removed the reported unused import `use std::os::unix::fs::PermissionsExt;` at `system/backends/appliance/initramfs/init.rs:2` by replacing usages of `std::fs::Permissions::from_mode` with the fully-qualified trait implementation path `<std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode`.
💡 **Why:** It eliminates an unused import from the top scope while safely maintaining compatibility with the required trait method (which caused a build error when just removed naively).
✅ **Verification:** Verified by compiling the file directly using `rustc` and validating the workspace using `scripts/ci-rust-core.sh`.
✨ **Result:** Cleaned up the imports and formatted the file, achieving a healthier codebase structure without changing any underlying boot behavior.

---
*PR created automatically by Jules for task [14458611679427024160](https://jules.google.com/task/14458611679427024160) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import/style cleanup in early boot init with no logic changes; boot behavior should be identical.
> 
> **Overview**
> Removes the top-level `PermissionsExt` import in the appliance initramfs `init.rs` and calls `from_mode` via fully qualified syntax at the two `set_permissions` sites so the trait method still resolves without the import.
> 
> The rest of the diff is **formatting only** (multiline `if`, `mount`, and boot banner `println!` calls); mount order, directory modes, and dinit handoff are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2856c2d81ad6d3c37e745b9297e3e2768c19a10a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->