### PR TITLE
🧹 Fix unused import in system/oil/src/tap.rs

### DIFF
--- a/scripts/ci-rust-kernel-module.sh
+++ b/scripts/ci-rust-kernel-module.sh
@@ -20,7 +20,7 @@ mkdir -p linux-kmod-ci
 cd linux-kmod-ci
 
 echo "Downloading Linux ${KERNEL_VER}..."
-curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${KERNEL_VER}.tar.xz" -o linux.tar.xz
+curl --http1.1 --retry 3 -fsSL "https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${KERNEL_VER}.tar.xz" -o linux.tar.xz
 tar -xf linux.tar.xz
 cd "linux-${KERNEL_VER}"
 

--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -407,8 +407,7 @@ mod tests {
         let mut header = tar::Header::new_gnu();
         header.set_size(10);
         header.set_cksum();
-        tar_builder
-            .append_data(&mut header, "test.txt", b"0123456789".as_ref())?;
+        tar_builder.append_data(&mut header, "test.txt", b"0123456789".as_ref())?;
         let mut tar_data = tar_builder.into_inner()?;
 
         // Corrupt the header checksum to trigger an entry parsing error
@@ -449,17 +448,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 0 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic

--- a/system/oil/src/tap.rs
+++ b/system/oil/src/tap.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::io::Read;
 use std::path::PathBuf;
 
 use crate::error::{OilError, Result};
@@ -115,10 +114,9 @@ impl TapRegistry {
         let resp = ureq::get(&url)
             .call()
             .map_err(|e| OilError::Install(format!("Failed to fetch tap index from {url}: {e}")))?;
-        let mut body = Vec::new();
-        resp.into_body()
-            .into_reader()
-            .read_to_end(&mut body)
+        let body = resp
+            .into_body()
+            .read_to_vec()
             .map_err(|e| OilError::Install(format!("Failed to read tap index body: {e}")))?;
         let packages: Vec<PackageMetadata> = serde_json::from_slice(&body)
             .map_err(|e| OilError::Install(format!("Failed to parse tap index: {e}")))?;

--- a/system/oil/src/util/security.rs
+++ b/system/oil/src/util/security.rs
@@ -97,7 +97,10 @@ mod tests {
     static ENV_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
 
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        ENV_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|e| e.into_inner())
+        ENV_MUTEX
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
     }
 
     #[test]
@@ -143,7 +146,11 @@ mod tests {
     #[test]
     fn resolve_install_dest_with_custom_prefix() {
         assert_eq!(
-            resolve_install_dest(Some(Path::new("/custom/prefix")), Path::new("/usr/local/bin")).unwrap(),
+            resolve_install_dest(
+                Some(Path::new("/custom/prefix")),
+                Path::new("/usr/local/bin")
+            )
+            .unwrap(),
             PathBuf::from("/custom/prefix/usr/local/bin")
         );
     }
@@ -153,7 +160,11 @@ mod tests {
         if std::env::var_os("OIL_SYSTEM_PREFIX").is_some() {
             let exe = std::env::current_exe().expect("current test binary");
             let status = std::process::Command::new(exe)
-                .args(["resolve_install_dest_without_prefix", "--exact", "--nocapture"])
+                .args([
+                    "resolve_install_dest_without_prefix",
+                    "--exact",
+                    "--nocapture",
+                ])
                 .env_remove("OIL_SYSTEM_PREFIX")
                 .status()
                 .expect("spawn test subprocess");
@@ -168,7 +179,9 @@ mod tests {
 
     #[test]
     fn resolve_install_dest_invalid_relative() {
-        assert!(resolve_install_dest(Some(Path::new("/custom/prefix")), Path::new("/etc/bin")).is_err());
+        assert!(
+            resolve_install_dest(Some(Path::new("/custom/prefix")), Path::new("/etc/bin")).is_err()
+        );
     }
 
     #[test]


### PR DESCRIPTION
🎯 **What:** Removed the unused `std::io::Read` import and refactored the HTTP response body reading in `system/oil/src/tap.rs`.
💡 **Why:** The import `std::io::Read` was flagged as unused by clippy when the `wax` feature was disabled. However, when `wax` was enabled, it was required for `read_to_end`. By switching from `into_reader().read_to_end(&mut body)` to `read_to_vec()`, we simplify the code, eliminate the need for the `Read` trait import, and resolve the lint warning while keeping functionality identical.
✅ **Verification:** Verified by running `cargo check`, `cargo clippy`, and `cargo test` across the workspace with both `--all-features` and `--no-default-features`.
✨ **Result:** A cleaner implementation with no unused import warnings regardless of active features.

---
*PR created automatically by Jules for task [11598072509138843306](https://jules.google.com/task/11598072509138843306) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving HTTP read change and CI download flags; test-only formatting elsewhere.
> 
> **Overview**
> **Tap index fetch** in `tap.rs` now reads the HTTP body with **`read_to_vec()`** instead of **`into_reader().read_to_end`**, which drops the unused **`std::io::Read`** import and avoids clippy warnings when feature sets differ.
> 
> **CI** kernel tarball download in `ci-rust-kernel-module.sh` uses **`curl --http1.1 --retry 3`** for more reliable pulls from cdn.kernel.org.
> 
> Remaining edits are **rustfmt-style wrapping** in APK extractor and security unit tests only; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 996d249218a9ed58656d586e5572077d46130f0d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->