### PR TITLE
🧹 Fix false positive unused import code health issue in init.rs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -1,4 +1,5 @@
 // Alpenglow Rust init — replaces the shell /init script
+// Required for `Permissions::from_mode`
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::process::CommandExt;
 use std::process::Command;
@@ -10,7 +11,11 @@ fn main() {
         if let Err(e) = std::fs::create_dir_all(d) {
             eprintln!("init: failed to create directory {}: {}", d, e);
         }
-        let mode = if *d == "/dev/shm" || *d == "/tmp" { 0o1777 } else { 0o755 };
+        let mode = if *d == "/dev/shm" || *d == "/tmp" {
+            0o1777
+        } else {
+            0o755
+        };
         if let Err(e) = std::fs::set_permissions(d, std::fs::Permissions::from_mode(mode)) {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
@@ -29,15 +34,22 @@ fn main() {
             }
         }
     }
-    run("mount", &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
+    );
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+    );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
     if let Err(e) = std::os::unix::fs::chown("/run/user/0", Some(0), Some(0)) {
         eprintln!("init: failed to chown /run/user/0: {}", e);
     }
-    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700))
+    {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
@@ -51,7 +63,9 @@ fn main() {
             _ => {}
         }
     }
-    println!(); println!("Alpenglow boot (rust-init)"); println!();
+    println!();
+    println!("Alpenglow boot (rust-init)");
+    println!();
     let err = Command::new("/usr/sbin/dinit")
         .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
         .env_clear()


### PR DESCRIPTION
🎯 **What:** Added a comment above the `use std::os::unix::fs::PermissionsExt;` import in `system/backends/appliance/initramfs/init.rs` to explicitly document that it is required for the `Permissions::from_mode()` method to compile, neutralizing a false positive code health alert claiming it was an unused import.

💡 **Why:** A static analysis tool incorrectly flagged the import as unused, but removing it breaks the compilation because the `from_mode` method is part of the `PermissionsExt` trait. Removing the import and fully-qualifying the method call (e.g. `<std::fs::Permissions as std::os::unix::fs::PermissionsExt>::from_mode(mode)`) drastically degraded code readability. Adding a clear comment preserves the original readability while documenting its necessity for future developers or automated tools. Additionally, ran `rustfmt` to improve the overall file formatting.

✅ **Verification:** 
- Verified that compiling the script locally using `rustc -W unused_imports system/backends/appliance/initramfs/init.rs` succeeds with no warnings about unused imports.
- Formatted the file and ran `clippy-driver` successfully.
- Ran `scripts/ci-rust-core.sh` to ensure no regressions were introduced across the workspace.

✨ **Result:** The code health issue is addressed via proper documentation, and the file is now formatted idiomatically, improving overall maintainability without altering functionality or introducing verbose syntax.

---
*PR created automatically by Jules for task [7214695471578694511](https://jules.google.com/task/7214695471578694511) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2db2d5540211e03488ab69fa1f546bc143e4db19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->