### PR TITLE
🔒 Fix insecure symlink validation in process_tar_entry

### DIFF
--- a/system/oil/src/system/extractor/apk.rs
+++ b/system/oil/src/system/extractor/apk.rs
@@ -193,7 +193,10 @@ fn is_safe_symlink(link_target: &Path, dest: &Path, dest_dir: &Path) -> bool {
             std::path::Component::Normal(c) => {
                 resolved.push(c);
             }
-            _ => continue,
+            std::path::Component::Prefix(_) | std::path::Component::RootDir => {
+                return false;
+            }
+            std::path::Component::CurDir => continue,
         }
     }
 
@@ -332,6 +335,29 @@ mod tests {
     }
 
     #[test]
+    fn test_is_safe_symlink_path_traversal() {
+        let dest_dir = Path::new("/extract");
+        let dest = Path::new("/extract/file");
+
+        // Safe cases
+        assert!(is_safe_symlink(Path::new("a/b/c"), dest, dest_dir));
+        assert!(is_safe_symlink(
+            Path::new("../file2"),
+            Path::new("/extract/dir/file"),
+            dest_dir
+        ));
+
+        // Unsafe cases
+        assert!(!is_safe_symlink(Path::new("/etc/passwd"), dest, dest_dir));
+        assert!(!is_safe_symlink(
+            Path::new("../../../etc/passwd"),
+            dest,
+            dest_dir
+        ));
+
+    }
+
+    #[test]
     fn test_split_gzip_streams_happy_path() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let stream1 = create_gz_stream(b"stream 1 data")?;
         let stream2 = create_gz_stream(b"stream 2 data")?;
@@ -407,8 +433,7 @@ mod tests {
         let mut header = tar::Header::new_gnu();
         header.set_size(10);
         header.set_cksum();
-        tar_builder
-            .append_data(&mut header, "test.txt", b"0123456789".as_ref())?;
+        tar_builder.append_data(&mut header, "test.txt", b"0123456789".as_ref())?;
         let mut tar_data = tar_builder.into_inner()?;
 
         // Corrupt the header checksum to trigger an entry parsing error
@@ -449,17 +474,23 @@ mod tests {
     }
 
     #[test]
-    fn test_split_gzip_streams_no_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_no_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let data = b"dummy string without gzip magic bytes";
         let result = split_gzip_streams(data, 3);
         assert!(result.is_err());
         let err_msg = result.expect_err("Expected an error").to_string();
-        assert!(err_msg.contains("APK has 0 gzip streams, expected 3"), "Unexpected error: {}", err_msg);
+        assert!(
+            err_msg.contains("APK has 0 gzip streams, expected 3"),
+            "Unexpected error: {}",
+            err_msg
+        );
         Ok(())
     }
 
     #[test]
-    fn test_split_gzip_streams_fake_magic_bytes() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn test_split_gzip_streams_fake_magic_bytes(
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
         let mut data = create_gz_stream(b"stream 1")?;
 
         // Append raw magic bytes in between valid streams to test the function's boundary splitting logic


### PR DESCRIPTION
🎯 **What:** Fixed an insecure symlink validation vulnerability in `process_tar_entry` that allowed absolute paths on some platforms to bypass directory checks.
⚠️ **Risk:** An attacker could craft a malicious tar archive with symlinks pointing outside the extraction directory (e.g., to the root of the drive on Windows), leading to path traversal and arbitrary file write when extracting.
🛡️ **Solution:** Modified `is_safe_symlink` to explicitly reject `std::path::Component::Prefix` and `std::path::Component::RootDir` components instead of ignoring them. This ensures that any path attempting to anchor to the root or a specific drive is securely rejected before evaluation. Added comprehensive unit tests to verify the behavior.

---
*PR created automatically by Jules for task [11877363798304018163](https://jules.google.com/task/11877363798304018163) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted security hardening in extraction with new tests; behavior change only rejects previously mishandled unsafe symlink targets.
> 
> **Overview**
> **Tightens symlink safety during Alpine APK extraction** by changing `is_safe_symlink` so `Prefix` and `RootDir` path components are **rejected** instead of being skipped via a catch-all `continue`. That closes a gap where platform-specific absolute path pieces (e.g. drive roots on Windows) could be ignored while resolving symlink targets, weakening the check that the resolved path stays under the extraction directory.
> 
> Adds **`test_is_safe_symlink_path_traversal`** covering in-bounds relative targets, parent-dir hops that remain under the dest tree, absolute targets, and `..` chains that escape. Includes minor test formatting only (no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ae01855c0399be23ac39063d75541f4939e373. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->