### PR TITLE
🧹 refactor(initramfs): resolve unused CommandExt import via fully-qualified syntax

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -1,6 +1,5 @@
 // Alpenglow Rust init — replaces the shell /init script
 use std::os::unix::fs::PermissionsExt;
-use std::os::unix::process::CommandExt;
 use std::process::Command;
 fn main() {
     run("mount", &["-t", "proc", "proc", "/proc"]);
@@ -10,7 +9,11 @@ fn main() {
         if let Err(e) = std::fs::create_dir_all(d) {
             eprintln!("init: failed to create directory {}: {}", d, e);
         }
-        let mode = if *d == "/dev/shm" || *d == "/tmp" { 0o1777 } else { 0o755 };
+        let mode = if *d == "/dev/shm" || *d == "/tmp" {
+            0o1777
+        } else {
+            0o755
+        };
         if let Err(e) = std::fs::set_permissions(d, std::fs::Permissions::from_mode(mode)) {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
@@ -29,15 +32,22 @@ fn main() {
             }
         }
     }
-    run("mount", &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"]);
-    run("mount", &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"]);
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
+    );
+    run(
+        "mount",
+        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+    );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);
     }
     if let Err(e) = std::os::unix::fs::chown("/run/user/0", Some(0), Some(0)) {
         eprintln!("init: failed to chown /run/user/0: {}", e);
     }
-    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700)) {
+    if let Err(e) = std::fs::set_permissions("/run/user/0", std::fs::Permissions::from_mode(0o700))
+    {
         eprintln!("init: failed to set permissions for /run/user/0: {}", e);
     }
     for m in &["ext4", "virtio-blk", "virtio-net", "snd", "snd-hda-intel"] {
@@ -51,11 +61,14 @@ fn main() {
             _ => {}
         }
     }
-    println!(); println!("Alpenglow boot (rust-init)"); println!();
-    let err = Command::new("/usr/sbin/dinit")
-        .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
-        .env_clear()
-        .exec();
+    println!();
+    println!("Alpenglow boot (rust-init)");
+    println!();
+    let err = std::os::unix::process::CommandExt::exec(
+        Command::new("/usr/sbin/dinit")
+            .args(["-d", "/etc/dinit.d", "-s", "-t", "shell-ttyS0"])
+            .env_clear(),
+    );
     eprintln!("init: dinit exec failed: {}", err);
     std::process::exit(1);
 }


### PR DESCRIPTION
🎯 **What:** Removed the `use std::os::unix::process::CommandExt;` import and updated the `Command::new(...).exec()` call to use the fully-qualified trait method `std::os::unix::process::CommandExt::exec(...)`. Also formatted the file.
💡 **Why:** A code health issue flagged the import as unused (likely a linter false positive since extension traits must be in scope to use their methods). By switching to the fully-qualified syntax, we eliminate the need for the import entirely while maintaining exact functionality.
✅ **Verification:** Compiled the standalone `init.rs` script using `rustc --edition 2021` with `-D unused_imports` to confirm compilation success and absence of warnings. Ran `scripts/ci-rust-core.sh` to ensure no workspace regressions.
✨ **Result:** A cleaner `init.rs` file that satisfies code health checks without any functional changes.

---
*PR created automatically by Jules for task [11298631288863034536](https://jules.google.com/task/11298631288863034536) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5d3748c65506c479f491c4e3a8f565d4c1303897. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->