### PR TITLE
🧪 Add negative edge cases to parseKind test

### DIFF
--- a/system/alpenglow-ctl/src/network.zig
+++ b/system/alpenglow-ctl/src/network.zig
@@ -391,4 +391,9 @@ test "parseKind handles valid and edge case inputs" {
     try testing.expectEqualStrings("ethernet", parseKind("1"));
     try testing.expectEqualStrings("loopback", parseKind("772"));
     try testing.expectEqualStrings("ethernet", parseKind("-1"));
+    try testing.expectEqualStrings("ethernet", parseKind(""));
+    try testing.expectEqualStrings("ethernet", parseKind("9999999999999999999999999"));
+    try testing.expectEqualStrings("ethernet", parseKind("-"));
+    try testing.expectEqualStrings("ethernet", parseKind("  "));
+    try testing.expectEqualStrings("ethernet", parseKind("\n"));
 }


### PR DESCRIPTION
🎯 **What:** The testing gap in `parseKind` was addressed by adding test cases for empty strings, extremely large strings (overflows), solitary invalid characters, and strings composed solely of whitespace.
📊 **Coverage:** The tests now explicitly cover inputs that will fail `std.fmt.parseInt` parsing, verifying that the `catch return "ethernet"` error handling path correctly defaults to "ethernet" for malformed sysfs values.
✨ **Result:** Test coverage is improved, ensuring robustness against malformed sysfs inputs and preventing future regressions in network interface kind detection.

---
*PR created automatically by Jules for task [2186081793317982507](https://jules.google.com/task/2186081793317982507) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production or behavioral modifications.
> 
> **Overview**
> Extends the **`parseKind`** unit test with five inputs that should fail **`std.fmt.parseInt`** parsing (empty string, integer overflow, lone `-`, whitespace-only, newline-only).
> 
> Each new assertion expects **`"ethernet"`**, locking in the existing **`catch return "ethernet"`** behavior for malformed sysfs **`type`** values. **No runtime code changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5a1fdd7c896bd6981189e9e42271a592d9c146f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->