### PR TITLE
🔒 Fix unsafe command construction in alpenglow-ctl zram spawnAndWait

### DIFF
--- a/system/alpenglow-ctl/src/zram.zig
+++ b/system/alpenglow-ctl/src/zram.zig
@@ -57,37 +57,18 @@ fn hotAddZram() !void {
 
 
 fn spawnAndWait(argv: []const []const u8) !void {
-    if (argv.len == 0 or argv.len > 16) return error.ChildProcessFailed;
-    var buf: [16][256]u8 = undefined;
-    var arg_ptrs: [17:null]?[*:0]u8 = undefined;
-    for (argv, 0..) |arg, i| {
-        if (arg.len >= 256) return error.ChildProcessFailed;
-        @memcpy(buf[i][0..arg.len], arg);
-        buf[i][arg.len] = 0;
-        arg_ptrs[i] = buf[i][0..arg.len :0];
-    }
-    arg_ptrs[argv.len] = null;
-    const env_array = &[_:null]?[*:0]const u8{null};
-    const env: [*:null]const ?[*:0]const u8 = env_array;
+    if (argv.len == 0) return error.ChildProcessFailed;
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
 
-    const pid = linux.fork();
-    if (pid == 0) {
-        _ = linux.execve(arg_ptrs[0].?, &arg_ptrs, env);
-        std.process.exit(255);
-    } else if (getErrno(pid) != .SUCCESS) {
-        return error.ChildProcessFailed;
-    } else {
-        var status: u32 = undefined;
-        while (true) {
-            const rc = linux.waitpid(@intCast(pid), &status, 0);
-            if (getErrno(rc) != .SUCCESS) {
-                if (getErrno(rc) == .INTR) continue;
-                return error.ChildProcessFailed;
-            }
-            break;
-        }
-        const code = linux.W.EXITSTATUS(status);
-        if (code != 0 and code != 255) return error.ChildProcessFailed;
+    var child = std.process.Child.init(argv, allocator);
+    const term = child.spawnAndWait() catch return error.ChildProcessFailed;
+    switch (term) {
+        .Exited => |code| {
+            if (code != 0 and code != 255) return error.ChildProcessFailed;
+        },
+        else => return error.ChildProcessFailed,
     }
 }
 


### PR DESCRIPTION
🎯 **What:** 
The `spawnAndWait` function in `system/alpenglow-ctl/src/zram.zig` constructed child process arguments using a manually managed, fixed-size 2D buffer (`[16][256]u8`), imposing arbitrary limits on argument count (max 16) and argument length (max 255 chars). Additionally, it manually executed raw `linux.fork()` and `linux.execve()` calls directly.

⚠️ **Risk:** 
While the current calling sites hardcode paths (e.g., `/usr/sbin/mkswap`, `/dev/zram0`), making it currently unexploitable, the original implementation was highly fragile and represented extremely poor security hygiene for a privileged system component. Using manual buffers to assemble pointers arrays is prone to off-by-one errors or truncation issues. If arguments ever became dynamic or slightly longer, it could result in silent truncation or an out-of-bounds buffer failure that compromises the process. Also, it didn't strictly check whether a process crashed vs exited cleanly when checking the exit status.

🛡️ **Solution:** 
Replaced the brittle custom string buffers and raw fork/execve logic with Zig's standard library `std.process.Child`. Memory for the child process execution context is now safely and dynamically allocated using an `std.heap.ArenaAllocator`, meaning dynamic argument sizes/counts are natively handled. It now also uses standard library execution which safely verifies exit statuses, explicitly validating that the program successfully terminated with code 0 or 255. A small check `if (argv.len == 0)` was re-added before execution to gracefully handle empty inputs without causing an allocator panic in the standard library implementation.

---
*PR created automatically by Jules for task [3429011215207708644](https://jules.google.com/task/3429011215207708644) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 492048ba8d36b83f924040a445564b0e61774843. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->