### PR TITLE
🔒 Fix insecure `/tmp` mount options in Rust Initramfs

### DIFF
--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -39,7 +39,14 @@ fn main() {
     );
     run(
         "/bin/mount",
-        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+        &[
+            "-t",
+            "tmpfs",
+            "-o",
+            "mode=1777,noexec,nosuid,nodev",
+            "tmpfs",
+            "/tmp",
+        ],
     );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the insecure mounting of the `/tmp` directory with execution permissions in the Rust Initramfs environment.
⚠️ **Risk:** If left unfixed, mounting `/tmp` with exec permissions allows potential malware or unintended binaries to be executed from a world-writable directory, putting the system and its users at risk.
🛡️ **Solution:** The fix addresses the vulnerability by appending `,noexec,nosuid,nodev` to the mount options for the `/tmp` directory in `system/backends/appliance/initramfs/init.rs`.

---
*PR created automatically by Jules for task [6702368503009593905](https://jules.google.com/task/6702368503009593905) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches initramfs PID 1 mount setup on the boot path; low blast radius unless something in early boot relied on executing from `/tmp`.
> 
> **Overview**
> Hardens early-boot `/tmp` in the **Rust initramfs** (`init.rs`) by extending the tmpfs mount from `mode=1777` to **`mode=1777,noexec,nosuid,nodev`**, so world-writable `/tmp` cannot execute binaries, honor setuid bits, or expose device nodes.
> 
> This is a targeted mount-option change only; `/dev/shm` and other mounts are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d907cc04081c0d794563412922f9eb349c4f0652. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->