### PR TITLE
🔒 Fix insecure temporary directory permissions in init scripts

### DIFF
--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -101,13 +101,13 @@ pub fn main() void {
     mount("tmpfs", "/run", "tmpfs", 0, null) catch {};
 
     mkdir("/dev/shm", 0o1777);
-    mount("tmpfs", "/dev/shm", "tmpfs", 0, @ptrFromInt(@intFromPtr(shm_mount_opts()))) catch {};
+    mount("tmpfs", "/dev/shm", "tmpfs", std.os.linux.MS.NOSUID | std.os.linux.MS.NODEV | std.os.linux.MS.NOEXEC, @ptrFromInt(@intFromPtr(shm_mount_opts()))) catch {};
 
     mkdir("/run/user", 0o755);
     mkdir("/run/user/0", 0o700);
     mkdir("/state", 0o700);
     mkdir("/tmp", 0o1777);
-    mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
+    mount("tmpfs", "/tmp", "tmpfs", std.os.linux.MS.NOSUID | std.os.linux.MS.NODEV | std.os.linux.MS.NOEXEC, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
 
     write_console("\nAlpenglow boot\n\n");
 


### PR DESCRIPTION
Addresses vulnerability regarding missing security-hardening options for `/tmp` and `/dev/shm` mounts in the Zig initialization script. Added standard `nosuid`, `nodev`, and `noexec` flags to reduce attack surface and prevent execution or device creation within these world-writable temporary filesystems.

---
*PR created automatically by Jules for task [13753086134689983006](https://jules.google.com/task/13753086134689983006) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to init-time mount flags on two tmpfs paths; low risk but affects every boot and could break workloads that relied on executing binaries or creating devices in `/tmp` or `/dev/shm`.
> 
> **Overview**
> **Hardens early-boot tmpfs mounts** for world-writable paths by passing `std.os.linux.MS.NOSUID | MS.NODEV | MS.NOEXEC` into the `mount` syscall for `/dev/shm` and `/tmp` in `init.zig`, instead of mount flags `0`.
> 
> This aligns those mounts with common hardening practice: no SUID binaries, no device nodes, and no execution from those filesystems, while keeping existing tmpfs options (`mode=1777` and dynamic `shm_mount_opts()` sizing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d2732ba222d82913fa631126b08edd7cf539a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->