### PR TITLE
🔒 Fix insecure temporary directory /tmp permissions (Shell Initramfs)

### DIFF
--- a/scripts/build-aarch64-desktop.sh
+++ b/scripts/build-aarch64-desktop.sh
@@ -86,7 +86,7 @@ mount -t sysfs sysfs /sys
 mount -t devtmpfs devtmpfs /dev
 mount -t devpts devpts /dev/pts
 [ -e /dev/ptmx ] || ln -s pts/ptmx /dev/ptmx
-mount -t tmpfs tmpfs /run
+mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run
 printf 'Alpenglow aarch64 root ready\n' > /dev/console
 mkdir -p /state /home
 mount -L alpenglow-state /state 2>/dev/null || true

--- a/scripts/build-aarch64-fast.sh
+++ b/scripts/build-aarch64-fast.sh
@@ -87,7 +87,7 @@ else
 /bin/toybox mount -t proc proc /proc
 /bin/toybox mount -t sysfs sysfs /sys
 /bin/toybox mount -t devtmpfs devtmpfs /dev
-/bin/toybox mount -t tmpfs tmpfs /run
+/bin/toybox mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run
 /bin/toybox mkdir -p /dev/shm 2>/dev/null
 SHM_SIZE="mode=1777,size=256m"
 if [ -r /proc/meminfo ]; then
@@ -99,7 +99,7 @@ if [ -r /proc/meminfo ]; then
     SHM_SIZE="mode=1777,size=$((mem_total_kb / 2))k"
   fi
 fi
-/bin/toybox mount -t tmpfs -o "$SHM_SIZE" tmpfs /dev/shm
+/bin/toybox mount -t tmpfs -o nosuid,nodev,"$SHM_SIZE" tmpfs /dev/shm
 /bin/toybox mkdir -p /run/user/0
 /bin/toybox chmod 700 /run/user/0
 /bin/toybox mkdir -p /state
@@ -122,7 +122,7 @@ SVC
 
 cat > "${ROOTFS_DIR}/etc/dinit.d/mount-filesystems" <<'SVC'
 type = scripted
-command = /bin/toybox sh -c "/bin/toybox mount -t proc proc /proc; /bin/toybox mount -t sysfs sysfs /sys; /bin/toybox mount -t devtmpfs devtmpfs /dev; /bin/toybox mount -t tmpfs tmpfs /run"
+command = /bin/toybox sh -c "/bin/toybox mount -t proc proc /proc; /bin/toybox mount -t sysfs sysfs /sys; /bin/toybox mount -t devtmpfs devtmpfs /dev; /bin/toybox mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run"
 restart = no
 SVC
 

--- a/scripts/build-v86-initramfs.sh
+++ b/scripts/build-v86-initramfs.sh
@@ -250,7 +250,7 @@ export COLORTERM=truecolor
   /bin/mknod /dev/ttyS0 c 4 64 2>/dev/null
   /bin/mknod /dev/null c 1 3 2>/dev/null
 }
-/bin/mount -t tmpfs tmpfs /run 2>/dev/null
+/bin/mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run 2>/dev/null
 /bin/hostname alpenglow 2>/dev/null
 [ -c "$CON" ] || CON=/dev/console
 cd /

--- a/scripts/lib/assemble-rootfs.sh
+++ b/scripts/lib/assemble-rootfs.sh
@@ -15,7 +15,7 @@ SHELL
 
   cat > "${ROOTFS_DIR}/etc/dinit.d/mount-filesystems" << 'MOUNT'
 type = scripted
-command = /bin/toybox sh -c "/bin/toybox mount -t proc proc /proc; /bin/toybox mount -t sysfs sysfs /sys; /bin/toybox mount -t devtmpfs devtmpfs /dev; /bin/toybox mount -t tmpfs tmpfs /run"
+command = /bin/toybox sh -c "/bin/toybox mount -t proc proc /proc; /bin/toybox mount -t sysfs sysfs /sys; /bin/toybox mount -t devtmpfs devtmpfs /dev; /bin/toybox mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run"
 restart = no
 MOUNT
 }
@@ -115,7 +115,7 @@ SCRIPT
 /bin/toybox mount -t sysfs sysfs /sys
 /bin/toybox mount -t devtmpfs devtmpfs /dev
 exec </dev/ttyS0 >/dev/ttyS0 2>&1
-/bin/toybox mount -t tmpfs tmpfs /run
+/bin/toybox mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run
 /bin/toybox mkdir -p /dev/shm /tmp 2>/dev/null
 /bin/toybox chmod 01777 /dev/shm /tmp
 SHM_SIZE="mode=1777,size=256m"
@@ -128,8 +128,8 @@ if [ -r /proc/meminfo ]; then
     SHM_SIZE="mode=1777,size=$((mem_total_kb / 2))k"
   fi
 fi
-/bin/toybox mount -t tmpfs -o "$SHM_SIZE" tmpfs /dev/shm
-/bin/toybox mount -t tmpfs -o mode=1777 tmpfs /tmp
+/bin/toybox mount -t tmpfs -o nosuid,nodev,"$SHM_SIZE" tmpfs /dev/shm
+/bin/toybox mount -t tmpfs -o nosuid,nodev,mode=1777 tmpfs /tmp
 /bin/toybox mkdir -p /run/user/0
 /bin/toybox chown 0:0 /run/user/0
 /bin/toybox chmod 700 /run/user/0

--- a/scripts/test-aarch64-installers.sh
+++ b/scripts/test-aarch64-installers.sh
@@ -71,7 +71,7 @@ mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 mount -t devtmpfs devtmpfs /dev
 exec >/dev/ttyAMA0 2>&1
-mount -t tmpfs tmpfs /run
+mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run
 echo "Alpenglow standard aarch64 installer smoke"
 TERM=xterm /bin/alpenglow-install --tui || true
 echo "Alpenglow standard installer smoke OK"
@@ -109,8 +109,8 @@ mount -t proc proc /proc
 mount -t sysfs sysfs /sys
 mount -t devtmpfs devtmpfs /dev
 exec >/dev/ttyAMA0 2>&1
-mount -t tmpfs tmpfs /run
-mount -t tmpfs tmpfs /tmp
+mount -t tmpfs -o nosuid,nodev,mode=0755 tmpfs /run
+mount -t tmpfs -o nosuid,nodev,mode=1777 tmpfs /tmp
 mkdir -p /run/seatd /run/user/0
 export XDG_RUNTIME_DIR=/run/user/0
 export LIBSEAT_BACKEND=seatd

--- a/system/backends/appliance/initramfs/init
+++ b/system/backends/appliance/initramfs/init
@@ -21,8 +21,8 @@ if [ -r /proc/meminfo ]; then
     SHM_SIZE="mode=1777,size=$((mem_total_kb / 2))k"
   fi
 fi
-mount -t tmpfs -o "$SHM_SIZE" tmpfs /dev/shm
-mount -t tmpfs -o mode=1777 tmpfs /tmp
+mount -t tmpfs -o nosuid,nodev,"$SHM_SIZE" tmpfs /dev/shm
+mount -t tmpfs -o nosuid,nodev,mode=1777 tmpfs /tmp
 mkdir -p /run/user/0 /tmp /mnt/root
 chown 0:0 /run/user/0 2>/dev/null || true
 chmod 700 /run/user/0 2>/dev/null || true

--- a/system/backends/appliance/initramfs/init.rs
+++ b/system/backends/appliance/initramfs/init.rs
@@ -19,7 +19,7 @@ fn main() {
             eprintln!("init: failed to set permissions for directory {}: {}", d, e);
         }
     }
-    run("/bin/mount", &["-t", "tmpfs", "tmpfs", "/run"]);
+    run("/bin/mount", &["-t", "tmpfs", "-o", "nosuid,nodev,mode=0755", "tmpfs", "/run"]);
     let mut shm_size = String::from("mode=1777,size=256m");
     if let Ok(meminfo) = std::fs::read_to_string("/proc/meminfo") {
         for line in meminfo.lines() {
@@ -35,11 +35,11 @@ fn main() {
     }
     run(
         "/bin/mount",
-        &["-t", "tmpfs", "-o", &shm_size, "tmpfs", "/dev/shm"],
+        &["-t", "tmpfs", "-o", &format!("nosuid,nodev,{}", shm_size), "tmpfs", "/dev/shm"],
     );
     run(
         "/bin/mount",
-        &["-t", "tmpfs", "-o", "mode=1777", "tmpfs", "/tmp"],
+        &["-t", "tmpfs", "-o", "nosuid,nodev,mode=1777", "tmpfs", "/tmp"],
     );
     if let Err(e) = std::fs::create_dir_all("/run/user/0") {
         eprintln!("init: failed to create directory /run/user/0: {}", e);

--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -6,11 +6,11 @@ fn shm_mount_opts() [*:0]const u8 {
     const AT_FDCWD: i64 = -100;
     const O_RDONLY: u32 = 0;
     const fd = std.os.linux.syscall3(.openat, @as(u64, @bitCast(AT_FDCWD)), @intFromPtr("/proc/meminfo"), O_RDONLY);
-    if (syserr2errno(fd) != .SUCCESS) return "nosuid,nodev,mode=1777,size=256m";
+    if (syserr2errno(fd) != .SUCCESS) return "mode=1777,size=256m";
     var buf: [1024]u8 = undefined;
     const n = std.os.linux.syscall3(.read, @as(usize, @intCast(fd)), @intFromPtr(&buf), buf.len);
     _ = std.os.linux.syscall1(.close, @as(usize, @intCast(fd)));
-    if (syserr2errno(n) != .SUCCESS) return "nosuid,nodev,mode=1777,size=256m";
+    if (syserr2errno(n) != .SUCCESS) return "mode=1777,size=256m";
     var i: usize = 0;
     var total: u64 = 0;
     const prefix = "MemTotal:";
@@ -25,8 +25,8 @@ fn shm_mount_opts() [*:0]const u8 {
             break;
         }
     }
-    if (total == 0) return "nosuid,nodev,mode=1777,size=256m";
-    _ = std.fmt.bufPrintZ(&SHM_OPTS, "nosuid,nodev,mode=1777,size={}k", .{total / 2}) catch return "nosuid,nodev,mode=1777,size=256m";
+    if (total == 0) return "mode=1777,size=256m";
+    _ = std.fmt.bufPrintZ(&SHM_OPTS, "mode=1777,size={}k", .{total / 2}) catch return "mode=1777,size=256m";
     return &SHM_OPTS;
 }
 
@@ -97,17 +97,19 @@ pub fn main() void {
     mkdir("/dev", 0o755);
     mount("devtmpfs", "/dev", "devtmpfs", 0, null) catch {};
 
+    const tmpfs_flags: u64 = std.os.linux.MS.NOSUID | std.os.linux.MS.NODEV;
+
     mkdir("/run", 0o755);
-    mount("tmpfs", "/run", "tmpfs", 0, @ptrFromInt(@intFromPtr("nosuid,nodev,mode=0755"))) catch {};
+    mount("tmpfs", "/run", "tmpfs", tmpfs_flags, @ptrFromInt(@intFromPtr("mode=0755"))) catch {};
 
     mkdir("/dev/shm", 0o1777);
-    mount("tmpfs", "/dev/shm", "tmpfs", 0, @ptrFromInt(@intFromPtr(shm_mount_opts()))) catch {};
+    mount("tmpfs", "/dev/shm", "tmpfs", tmpfs_flags, @ptrFromInt(@intFromPtr(shm_mount_opts()))) catch {};
 
     mkdir("/run/user", 0o755);
     mkdir("/run/user/0", 0o700);
     mkdir("/state", 0o700);
     mkdir("/tmp", 0o1777);
-    mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("nosuid,nodev,mode=1777"))) catch {};
+    mount("tmpfs", "/tmp", "tmpfs", tmpfs_flags, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
 
     write_console("\nAlpenglow boot\n\n");
 

--- a/system/init/init.zig
+++ b/system/init/init.zig
@@ -6,11 +6,11 @@ fn shm_mount_opts() [*:0]const u8 {
     const AT_FDCWD: i64 = -100;
     const O_RDONLY: u32 = 0;
     const fd = std.os.linux.syscall3(.openat, @as(u64, @bitCast(AT_FDCWD)), @intFromPtr("/proc/meminfo"), O_RDONLY);
-    if (syserr2errno(fd) != .SUCCESS) return "mode=1777,size=256m";
+    if (syserr2errno(fd) != .SUCCESS) return "nosuid,nodev,mode=1777,size=256m";
     var buf: [1024]u8 = undefined;
     const n = std.os.linux.syscall3(.read, @as(usize, @intCast(fd)), @intFromPtr(&buf), buf.len);
     _ = std.os.linux.syscall1(.close, @as(usize, @intCast(fd)));
-    if (syserr2errno(n) != .SUCCESS) return "mode=1777,size=256m";
+    if (syserr2errno(n) != .SUCCESS) return "nosuid,nodev,mode=1777,size=256m";
     var i: usize = 0;
     var total: u64 = 0;
     const prefix = "MemTotal:";
@@ -25,8 +25,8 @@ fn shm_mount_opts() [*:0]const u8 {
             break;
         }
     }
-    if (total == 0) return "mode=1777,size=256m";
-    _ = std.fmt.bufPrintZ(&SHM_OPTS, "mode=1777,size={}k", .{total / 2}) catch return "mode=1777,size=256m";
+    if (total == 0) return "nosuid,nodev,mode=1777,size=256m";
+    _ = std.fmt.bufPrintZ(&SHM_OPTS, "nosuid,nodev,mode=1777,size={}k", .{total / 2}) catch return "nosuid,nodev,mode=1777,size=256m";
     return &SHM_OPTS;
 }
 
@@ -98,7 +98,7 @@ pub fn main() void {
     mount("devtmpfs", "/dev", "devtmpfs", 0, null) catch {};
 
     mkdir("/run", 0o755);
-    mount("tmpfs", "/run", "tmpfs", 0, null) catch {};
+    mount("tmpfs", "/run", "tmpfs", 0, @ptrFromInt(@intFromPtr("nosuid,nodev,mode=0755"))) catch {};
 
     mkdir("/dev/shm", 0o1777);
     mount("tmpfs", "/dev/shm", "tmpfs", 0, @ptrFromInt(@intFromPtr(shm_mount_opts()))) catch {};
@@ -107,7 +107,7 @@ pub fn main() void {
     mkdir("/run/user/0", 0o700);
     mkdir("/state", 0o700);
     mkdir("/tmp", 0o1777);
-    mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("mode=1777"))) catch {};
+    mount("tmpfs", "/tmp", "tmpfs", 0, @ptrFromInt(@intFromPtr("nosuid,nodev,mode=1777"))) catch {};
 
     write_console("\nAlpenglow boot\n\n");
 


### PR DESCRIPTION
🎯 **What:** Adds `nosuid` and `nodev` secure mount flags to temporary `tmpfs` directories (`/run`, `/tmp`, `/dev/shm`) across initramfs and build scripts.
⚠️ **Risk:** Without these flags, malicious actors could potentially create device nodes or run SUID binaries from world-writable directories, leading to local privilege escalation or system compromise.
🛡️ **Solution:** Systematically appended `nosuid,nodev` to all `tmpfs` mount commands in bash scripts, the rust init implementation, and the zig init implementation to enforce strict permissions globally.

---
*PR created automatically by Jules for task [8721904844898285421](https://jules.google.com/task/8721904844898285421) started by @undivisible*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Boot-time mount flag hardening with no auth or data-model changes; unlikely to break normal workloads unless something depended on SUID binaries or device nodes on these tmpfs paths.
> 
> **Overview**
> Hardens early-boot **tmpfs** mounts by adding **`nosuid` and `nodev`** everywhere Alpenglow brings up **`/run`**, **`/tmp`**, and **`/dev/shm`**, while keeping existing **`mode`** and shm size behavior.
> 
> The same mount options are applied consistently across **shell initramfs** (`system/backends/appliance/initramfs/init`), **Rust** and **Zig** inits, **dinit** `mount-filesystems` units, and the **aarch64 / v86 build and QEMU installer smoke** scripts so generated images match the appliance init path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab7c3638305b749f54675ca6aac57d046ed6cc6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->